### PR TITLE
Fix flaky tests, refactor some code, clean clippy, and more.

### DIFF
--- a/cli/src/client/mod.rs
+++ b/cli/src/client/mod.rs
@@ -37,7 +37,7 @@ impl Client {
             .header("apollographql-client-name", "experimental-apollo-cli")
             .header(
                 "apollographql-client-version",
-                env::var("CARGO_PKG_VERSION").unwrap_or("dev".into()),
+                env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "dev".into()),
             )
             .header("x-api-key", &self.api_key)
             .json(&request_body)

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -38,7 +38,7 @@ impl Command for Setup {
         }
 
         debug!("Setting new key...");
-        session.config.api_key = Some(key.to_string());
+        session.config.api_key = Some(key);
 
         debug!("Saving new key...");
         CliConfig::save(&session.config_path, &session.config)?;

--- a/cli/src/commands/update.rs
+++ b/cli/src/commands/update.rs
@@ -30,8 +30,8 @@ impl Command for Update {
             archive_bin_name,
             filename,
             url,
-        } = get_latest_release()
-            .map_err(|e| ErrorDetails::CliInstallError { msg: e.to_string() })?;
+        } = get_latest_release(&session.cdn_host)?;
+
         let current_version = get_installed_version()
             .map_err(|e| ErrorDetails::CliInstallError { msg: e.to_string() })?;
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -95,29 +95,3 @@ impl CliConfig {
         })
     }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use std::env::set_var;
-//     use tempfile::tempdir;
-
-//     use super::CliConfig;
-
-//     // environment variables are a shared resource on the thread so we combine these tests
-//     // together to prevent env clobbering
-//     #[test]
-//     fn creates_machine_id_or_reads_it() -> Result<(), Box<dyn std::error::Error>> {
-//         let dir = tempdir().unwrap();
-//         set_var("HOME", dir.path());
-//         dbg!(dir.path());
-//         // write new config to $HOME
-//         let config = CliConfig::load()?;
-//         assert_ne!(config.machine_id.is_empty(), true);
-//         dbg!(std::env::var("HOME").unwrap());
-//         // read config
-//         let config_two = CliConfig::load()?;
-//         assert_eq!(config.machine_id, config_two.machine_id);
-
-//         Ok(())
-//     }
-// }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
 
     let latest_version_receiver = if should_check_for_updates {
         // Check for updates to the CLI in the background
-        Some(background_check_for_updates())
+        Some(background_check_for_updates(&session.cdn_host))
     } else {
         None
     };
@@ -73,7 +73,7 @@ fn main() {
     let _telemetry_reported = session.report().unwrap_or(false);
 
     // Check for updates to the CLI and print out a message if an update is ready
-    if let Some(Ok(latest_version)) = latest_version_receiver.map(|it| it.try_recv()) {
+    if let Some(Ok(latest_version)) = latest_version_receiver.map(|r| r.try_recv()) {
         ::log::info!(
             "\n > A new version of the Apollo CLI ({}) is available! To update, run `{} update`",
             style(latest_version).green().bold(),
@@ -116,8 +116,4 @@ fn setup_panic_hooks() {
                 .expect("human-panic: printing error message to console failed");
         }));
     }
-}
-
-pub fn domain() -> String {
-    env::var("APOLLO_CDN_URL").unwrap_or_else(|_| "https://install.apollographql.com".to_string())
 }

--- a/cli/src/version.rs
+++ b/cli/src/version.rs
@@ -76,8 +76,7 @@ fn get_version_disk(
     Ok(local_version)
 }
 
-// TODO(ran) FIXME: find new warnings
-pub(crate) fn get_latest_release(cdn_host: &String) -> Fallible<Release> {
+pub(crate) fn get_latest_release(cdn_host: &str) -> Fallible<Release> {
     let platform: &str = match OS {
         "macos" => Ok("darwin"),
         "linux" | "windows" => Ok(OS),

--- a/cli/src/version.rs
+++ b/cli/src/version.rs
@@ -93,9 +93,8 @@ pub(crate) fn get_latest_release(cdn_host: &str) -> Fallible<Release> {
         .map_err(|_err| ErrorDetails::ReleaseFetchError)?;
 
     if !resp.status().is_success() {
-        debug!("Request to load the latest release");
         debug!(
-            "response status is {}, response is {:?}",
+            "Request to load the latest release failed. status: {}, response: {:?}",
             resp.status(),
             resp
         );

--- a/cli/tests/cli-runtime.rs
+++ b/cli/tests/cli-runtime.rs
@@ -3,14 +3,8 @@ pub use utils::*; // this gets rid of a dead code warning.
 
 #[cfg(unix)]
 mod unix {
-    // use std::env::consts::OS;
-    // use std::error::Error;
-
     use assert_cmd::prelude::*;
     use predicates::prelude::*;
-    // use tempfile::tempdir;
-    // use wiremock::matchers::{method, PathExactMatcher};
-    // use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::utils;
 
@@ -24,64 +18,4 @@ mod unix {
 
         Ok(())
     }
-
-    // async fn create_mock_proxy(
-    //     response: ResponseTemplate,
-    // ) -> Result<MockServer, Box<dyn Error + 'static>> {
-    //     let proxy = MockServer::start().await;
-    //     let platform: Option<&str> = match OS {
-    //         "linux" | "macos" | "windows" => Some(OS),
-    //         _ => None,
-    //     };
-
-    //     Mock::given(method("HEAD"))
-    //         .and(PathExactMatcher::new(format!("cli/{}", platform.unwrap())))
-    //         .respond_with(response)
-    //         .expect(1..)
-    //         .mount(&proxy)
-    //         .await;
-
-    //     Ok(proxy)
-    // }
-
-    // this test only verifies that the request is sent to the CDN as the printing
-    // is flaky given its background thread status
-    // #[async_std::test]
-    // async fn prints_if_update_is_found() -> Result<(), Box<dyn std::error::Error>> {
-    //     // this test will start failing if when this package passes version 100.0.0
-    //     // if that ever happens, please send a nice bottle of gin to James Baxley
-    //     let response = ResponseTemplate::new(200)
-    //         .append_header("content-disposition", "filename=ap-v100.0.0-linux");
-    //     let proxy = create_mock_proxy(response).await.unwrap();
-
-    //     let mut cli = utils::get_cli();
-
-    //     cli.command
-    //         .arg("setup")
-    //         .env("APOLLO_CDN_URL", &proxy.uri())
-    //         .env("SHELL", "/usr/bin/zsh")
-    //         .assert()
-    //         .code(4);
-
-    //     Ok(())
-    // }
-
-    // #[async_std::test]
-    // async fn checks_for_updates_in_background() -> Result<(), Box<dyn std::error::Error>> {
-    //     let response =
-    //         ResponseTemplate::new(200).append_header("content-disposition", "filename=ap-v0.1-linux");
-
-    //     let proxy = create_mock_proxy(response).await.unwrap();
-    //     let mut cli = utils::get_cli();
-
-    //     cli.command
-    //         .arg("setup")
-    //         .env("APOLLO_CDN_URL", &proxy.uri())
-    //         .env("SHELL", "/usr/bin/zsh")
-    //         .assert()
-    //         .code(4)
-    //         .stderr(predicate::str::contains("Could not locate user profile"));
-
-    //     Ok(())
-    // }
 }

--- a/cli/tests/commands/schema/get.rs
+++ b/cli/tests/commands/schema/get.rs
@@ -1,7 +1,6 @@
 use crate::utils::{add_mock_graphql, get_cli};
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use rand;
 use rand::seq::SliceRandom;
 use serde_json::Value;
 use std::str;

--- a/graphql-parser/src/query/grammar.rs
+++ b/graphql-parser/src/query/grammar.rs
@@ -186,7 +186,7 @@ mod test {
     use crate::query::grammar::*;
 
     fn ast(s: &str) -> Document {
-        parse_query(&s).unwrap().to_owned()
+        parse_query(&s).unwrap()
     }
 
     #[test]
@@ -199,7 +199,7 @@ mod test {
                     items: vec![Selection::Field(Field {
                         position: Pos { line: 1, column: 3 },
                         alias: None,
-                        name: "a".into(),
+                        name: "a",
                         arguments: Vec::new(),
                         directives: Vec::new(),
                         selection_set: SelectionSet {
@@ -228,11 +228,11 @@ mod test {
                     items: vec![Selection::Field(Field {
                         position: Pos { line: 1, column: 3 },
                         alias: None,
-                        name: "a".into(),
+                        name: "a",
                         arguments: vec![
-                            ("t".into(), Value::Boolean(true)),
-                            ("f".into(), Value::Boolean(false)),
-                            ("n".into(), Value::Null),
+                            ("t", Value::Boolean(true)),
+                            ("f", Value::Boolean(false)),
+                            ("n", Value::Null),
                         ],
                         directives: Vec::new(),
                         selection_set: SelectionSet {

--- a/graphql-parser/src/schema/grammar.rs
+++ b/graphql-parser/src/schema/grammar.rs
@@ -598,7 +598,7 @@ mod test {
     use crate::position::Pos;
 
     fn ast(s: &str) -> Document {
-        parse_schema(&s).unwrap().to_owned()
+        parse_schema(&s).unwrap()
     }
 
     #[test]
@@ -609,7 +609,7 @@ mod test {
                 definitions: vec![Definition::Schema(SchemaDefinition {
                     position: Pos { line: 1, column: 1 },
                     directives: vec![],
-                    query: Some("Query".into()),
+                    query: Some("Query"),
                     mutation: None,
                     subscription: None
                 })],

--- a/graphql-parser/src/tokenizer.rs
+++ b/graphql-parser/src/tokenizer.rs
@@ -342,7 +342,7 @@ mod test {
                 Err(e) => panic!("Parse error at {}: {}", s.position(), e),
             }
         }
-        return r;
+        r
     }
     fn tok_typ(s: &str) -> Vec<Kind> {
         let mut r = Vec::new();
@@ -354,7 +354,7 @@ mod test {
                 Err(e) => panic!("Parse error at {}: {}", s.position(), e),
             }
         }
-        return r;
+        r
     }
 
     #[test]

--- a/query-planner/src/model.rs
+++ b/query-planner/src/model.rs
@@ -27,7 +27,7 @@ pub struct FetchNode {
     pub service_name: String,
     pub variable_usages: Vec<String>,
     pub requires: Option<SelectionSet>,
-    pub operation: String,
+    pub operation: GraphQLDocument,
 }
 
 #[derive(Debug, PartialEq)]
@@ -65,3 +65,4 @@ impl fmt::Display for ResponsePathElement {
 }
 
 pub type SelectionSet = Vec<Selection>;
+pub type GraphQLDocument = String;


### PR DESCRIPTION
This PR fixes https://github.com/apollographql/rust/issues/63

The issue contains a long comment on the path I went through to find the root cause, I _really_ took the long way around :)

The TL;DR: is 
* overriding `APOLLO_CDN_URL` in multiple tests caused a race condition for some tests to try and talk to the mock server set up by another test, because they find the mock server through the value in that environment variable.
* Along the way of finding the problem, I went through refactoring some of the code I saw along the way. Looking at individual commits should make it easier to understand.
* I deleted code that was commented out, it didn't seem valuable.
* Finally, I ran `cargo clippy`, found a lot of issues, cleaned them, and committed that too.

