### PR TITLE
Suggestions on top of qv-visitor #83

### DIFF
--- a/graphql-parser/build.rs
+++ b/graphql-parser/build.rs
@@ -13,10 +13,10 @@ fn main() -> std::io::Result<()> {
 #![allow(non_snake_case)]
 
 mod helpers;
-use helpers::*;
-use insta::assert_snapshot;
 use graphql_parser::parse_query;
 use graphql_parser::parse_schema;
+use helpers::*;
+use insta::assert_snapshot;
 use pretty_assertions::assert_eq;
 
 ",

--- a/graphql-parser/src/lib.rs
+++ b/graphql-parser/src/lib.rs
@@ -135,7 +135,7 @@
 //! You can also `map` an AST into another form.
 //!
 //! ```rust
-//! use graphql_parser::{parse_query, Map, query, query::{Node, Document, Definition, SelectionSet, Selection}};
+//! use graphql_parser::{parse_query, Fold, query, query::{Node, Document, Definition, SelectionSet, Selection}};
 //! let ast = graphql_parser::parse_query(r#"
 //! query {
 //!     someField
@@ -143,8 +143,8 @@
 //! }
 //! "#)?;
 //! struct ToIndentedNodeTypes {}
-//! impl Map for ToIndentedNodeTypes {
-//!     // We're mapping the query AST into a string
+//! impl Fold for ToIndentedNodeTypes {
+//!     // We're folding the query AST into a string
 //!     type Output = String;
 //!     // The *merge* function controls how we merge child output data up the tree
 //!     // when the map of the child is complete. Here we join parent and child
@@ -153,7 +153,7 @@
 //!         format!("{}\n{}", parent, child)
 //!     }
 //! }
-//! impl query::Map for ToIndentedNodeTypes {
+//! impl query::Fold for ToIndentedNodeTypes {
 //!     fn query<'a>(&mut self, _: &Document<'a>, stack: &[Self::Output]) -> Self::Output {
 //!         format!("{}query", "  ".repeat(stack.len()))
 //!     }
@@ -168,7 +168,7 @@
 //!     }
 //! }
 //!
-//! let tx = ast.map(ToIndentedNodeTypes{});
+//! let tx = ast.fold(ToIndentedNodeTypes{});
 //! pretty_assertions::assert_eq!(tx.output, Some(String::from("query
 //!   query_def
 //!     sel_set
@@ -203,4 +203,4 @@ pub use crate::schema::parse_schema;
 
 mod name;
 pub use crate::name::*;
-pub use visit::Map;
+pub use visit::Fold;

--- a/graphql-parser/src/lib.rs
+++ b/graphql-parser/src/lib.rs
@@ -114,11 +114,11 @@
 //! };
 //!
 //! /// Schemas can contain queries, so all visitors must at least implement query::Visitor.
-//! impl query::Visitor for Fields {}
+//! impl query::QueryVisitor for Fields {}
 //!
 //! /// To collect field definitions, we'll also want to implement the appropriate method of
 //! /// schema::Visitor
-//! impl schema::Visitor for Fields {
+//! impl schema::SchemaVisitor for Fields {
 //!     fn enter_field<'a>(&mut self, field: &schema::Field<'a>) {
 //!         self.output.push(String::from(field.name().unwrap()));
 //!     }

--- a/graphql-parser/src/lib.rs
+++ b/graphql-parser/src/lib.rs
@@ -114,11 +114,11 @@
 //! };
 //!
 //! /// Schemas can contain queries, so all visitors must at least implement query::Visitor.
-//! impl query::QueryVisitor for Fields {}
+//! impl query::Visitor for Fields {}
 //!
 //! /// To collect field definitions, we'll also want to implement the appropriate method of
 //! /// schema::Visitor
-//! impl schema::SchemaVisitor for Fields {
+//! impl schema::Visitor for Fields {
 //!     fn enter_field<'a>(&mut self, field: &schema::Field<'a>) {
 //!         self.output.push(String::from(field.name().unwrap()));
 //!     }

--- a/graphql-parser/src/lib.rs
+++ b/graphql-parser/src/lib.rs
@@ -168,8 +168,8 @@
 //!     }
 //! }
 //!
-//! let tx = ast.fold(ToIndentedNodeTypes{});
-//! pretty_assertions::assert_eq!(tx.output, Some(String::from("query
+//! let output = ast.fold(ToIndentedNodeTypes{});
+//! pretty_assertions::assert_eq!(output, Some(String::from("query
 //!   query_def
 //!     sel_set
 //!       sel

--- a/graphql-parser/src/query/grammar.rs
+++ b/graphql-parser/src/query/grammar.rs
@@ -180,7 +180,7 @@ pub fn parse_query(s: &str) -> Result<Document, ParseError> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::{Definition, Document, Field, Selection, SelectionSet, Value};
     use crate::position::Pos;
     use crate::query::grammar::*;

--- a/graphql-parser/src/query/visit.rs
+++ b/graphql-parser/src/query/visit.rs
@@ -2,7 +2,7 @@ use super::{Definition, Document, Selection, SelectionSet};
 use crate::{visit, visit_each};
 
 #[allow(unused_variables)]
-pub trait Visitor {
+pub trait QueryVisitor {
     fn enter_query(&mut self, doc: &Document) {}
     fn enter_query_def(&mut self, def: &Definition) {}
     fn enter_sel_set(&mut self, sel_set: &SelectionSet) {}
@@ -21,7 +21,7 @@ pub trait Fold: visit::Fold {
     fn sel(&mut self, sel: &Selection, stack: &[Self::Output]) -> Self::Output;
 }
 
-impl<F: Fold> Visitor for visit::Folding<F> {
+impl<F: Fold> QueryVisitor for visit::Folding<F> {
     fn enter_query(&mut self, doc: &Document) {
         self.stack.push(self.fold.query(doc, &self.stack));
     }
@@ -49,7 +49,7 @@ impl<F: Fold> Visitor for visit::Folding<F> {
 }
 
 pub trait Node {
-    fn accept<V: Visitor>(&self, visitor: &mut V);
+    fn accept<V: QueryVisitor>(&self, visitor: &mut V);
 
     fn fold<F: Fold>(&self, fold: F) -> visit::Folding<F> {
         let mut folding = visit::Folding::new(fold);
@@ -59,7 +59,7 @@ pub trait Node {
 }
 
 impl<'a> Node for Document<'a> {
-    fn accept<V: Visitor>(&self, visitor: &mut V) {
+    fn accept<V: QueryVisitor>(&self, visitor: &mut V) {
         visitor.enter_query(self);
         visit_each!(visitor: self.definitions);
         visitor.leave_query(self);
@@ -67,7 +67,7 @@ impl<'a> Node for Document<'a> {
 }
 
 impl<'a> Node for Definition<'a> {
-    fn accept<V: Visitor>(&self, visitor: &mut V) {
+    fn accept<V: QueryVisitor>(&self, visitor: &mut V) {
         visitor.enter_query_def(self);
         use Definition::*;
         match self {
@@ -80,7 +80,7 @@ impl<'a> Node for Definition<'a> {
 }
 
 impl<'a> Node for SelectionSet<'a> {
-    fn accept<V: Visitor>(&self, visitor: &mut V) {
+    fn accept<V: QueryVisitor>(&self, visitor: &mut V) {
         visitor.enter_sel_set(self);
         visit_each!(visitor: self.items);
         visitor.leave_sel_set(self);
@@ -88,7 +88,7 @@ impl<'a> Node for SelectionSet<'a> {
 }
 
 impl<'a> Node for Selection<'a> {
-    fn accept<V: Visitor>(&self, visitor: &mut V) {
+    fn accept<V: QueryVisitor>(&self, visitor: &mut V) {
         visitor.enter_sel(self);
         use Selection::*;
         match self {
@@ -102,7 +102,7 @@ impl<'a> Node for Selection<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Fold, Visitor};
+    use super::{Fold, QueryVisitor};
     use crate::query::{Definition, Document, Selection, SelectionSet, Node};
     use crate::visit;
 
@@ -138,7 +138,7 @@ mod tests {
         }
 
         use crate::Name;
-        impl Visitor for Print {
+        impl QueryVisitor for Print {
             print!(enter_query Document);
             print!(leave_query Document);
             print!(enter_query_def Definition);

--- a/graphql-parser/src/query/visit.rs
+++ b/graphql-parser/src/query/visit.rs
@@ -50,12 +50,9 @@ impl<F: Fold> Visitor for visit::Folding<F> {
 
 pub trait Node {
     fn accept<V: Visitor>(&self, visitor: &mut V);
+
     fn fold<F: Fold>(&self, fold: F) -> visit::Folding<F> {
-        let mut folding = visit::Folding {
-            stack: vec![],
-            fold,
-            output: None,
-        };
+        let mut folding = visit::Folding::new(fold);
         self.accept(&mut folding);
         folding
     }

--- a/graphql-parser/src/query/visit.rs
+++ b/graphql-parser/src/query/visit.rs
@@ -51,10 +51,10 @@ impl<F: Fold> QueryVisitor for visit::Folding<F> {
 pub trait Node {
     fn accept<V: QueryVisitor>(&self, visitor: &mut V);
 
-    fn fold<F: Fold>(&self, fold: F) -> visit::Folding<F> {
+    fn fold<F: Fold>(&self, fold: F) -> Option<F::Output> {
         let mut folding = visit::Folding::new(fold);
         self.accept(&mut folding);
-        folding
+        folding.output
     }
 }
 
@@ -233,9 +233,9 @@ mod tests {
             }
         }
 
-        let tx = query.fold(TestMap {});
+        let output = query.fold(TestMap {});
         pretty_assertions::assert_eq!(
-            tx.output,
+            output,
             Some(String::from(
                 r#"query
   query_def

--- a/graphql-parser/src/query/visit.rs
+++ b/graphql-parser/src/query/visit.rs
@@ -103,10 +103,16 @@ impl<'a> Node for Selection<'a> {
     }
 }
 
-#[test]
-fn visits_a_query() -> Result<(), super::ParseError> {
-    let query = super::parse_query(
-        r###"
+#[cfg(test)]
+mod tests {
+    use super::{Fold, Visitor};
+    use crate::query::{Definition, Document, Selection, SelectionSet, Node};
+    use crate::visit;
+
+    #[test]
+    fn visits_a_query() -> Result<(), crate::query::ParseError> {
+        let query = crate::query::parse_query(
+            r###"
     query SomeQuery {
         fieldA
         fieldB(arg: "hello", arg2: 48) {
@@ -119,114 +125,122 @@ fn visits_a_query() -> Result<(), super::ParseError> {
         }
     }
     "###,
-    )?;
+        )?;
 
-    struct Print {
-        output: Vec<String>,
-    };
-
-    macro_rules! print {
-        ($action:ident $Type:ident) => {
-            fn $action<'a>(&mut self, node: &$Type<'a>) {
-                self.output
-                    .push(format!("{} ({:?})", stringify!($action), node.name()));
-            }
+        struct Print {
+            output: Vec<String>,
         };
+
+        macro_rules! print {
+            ($action:ident $Type:ident) => {
+                fn $action<'a>(&mut self, node: &$Type<'a>) {
+                    self.output
+                        .push(format!("{} ({:?})", stringify!($action), node.name()));
+                }
+            };
+        }
+
+        use crate::Name;
+        impl Visitor for Print {
+            print!(enter_query Document);
+            print!(leave_query Document);
+            print!(enter_query_def Definition);
+            print!(leave_query_def Definition);
+            print!(enter_sel_set SelectionSet);
+            print!(leave_sel_set SelectionSet);
+            print!(enter_sel Selection);
+            print!(leave_sel Selection);
+        }
+
+        let mut print = Print { output: vec![] };
+        query.accept(&mut print);
+
+        assert_eq!(
+            print.output,
+            vec![
+                r#"enter_query (None)"#,
+                r#"enter_query_def (Some("SomeQuery"))"#,
+                r#"enter_sel_set (None)"#,
+                r#"enter_sel (Some("fieldA"))"#,
+                r#"enter_sel_set (None)"#,
+                r#"leave_sel_set (None)"#,
+                r#"leave_sel (Some("fieldA"))"#,
+                r#"enter_sel (Some("fieldB"))"#,
+                r#"enter_sel_set (None)"#,
+                r#"enter_sel (Some("innerFieldOne"))"#,
+                r#"enter_sel_set (None)"#,
+                r#"leave_sel_set (None)"#,
+                r#"leave_sel (Some("innerFieldOne"))"#,
+                r#"enter_sel (Some("innerFieldTwo"))"#,
+                r#"enter_sel_set (None)"#,
+                r#"leave_sel_set (None)"#,
+                r#"leave_sel (Some("innerFieldTwo"))"#,
+                r#"enter_sel (Some("fragmentSpread"))"#,
+                r#"leave_sel (Some("fragmentSpread"))"#,
+                r#"enter_sel (Some("SomeType"))"#,
+                r#"enter_sel_set (None)"#,
+                r#"enter_sel (Some("someTypeField"))"#,
+                r#"enter_sel_set (None)"#,
+                r#"leave_sel_set (None)"#,
+                r#"leave_sel (Some("someTypeField"))"#,
+                r#"leave_sel_set (None)"#,
+                r#"leave_sel (Some("SomeType"))"#,
+                r#"leave_sel_set (None)"#,
+                r#"leave_sel (Some("fieldB"))"#,
+                r#"leave_sel_set (None)"#,
+                r#"leave_query_def (Some("SomeQuery"))"#,
+                r#"leave_query (None)"#
+            ]
+        );
+
+        Ok(())
     }
 
-    use crate::Name;
-    impl Visitor for Print {
-        print!(enter_query Document);
-        print!(leave_query Document);
-        print!(enter_query_def Definition);
-        print!(leave_query_def Definition);
-        print!(enter_sel_set SelectionSet);
-        print!(leave_sel_set SelectionSet);
-        print!(enter_sel Selection);
-        print!(leave_sel Selection);
-    }
-
-    let mut print = Print { output: vec![] };
-    query.accept(&mut print);
-
-    assert_eq!(
-        print.output,
-        vec![
-            r#"enter_query (None)"#,
-            r#"enter_query_def (Some("SomeQuery"))"#,
-            r#"enter_sel_set (None)"#,
-            r#"enter_sel (Some("fieldA"))"#,
-            r#"enter_sel_set (None)"#,
-            r#"leave_sel_set (None)"#,
-            r#"leave_sel (Some("fieldA"))"#,
-            r#"enter_sel (Some("fieldB"))"#,
-            r#"enter_sel_set (None)"#,
-            r#"enter_sel (Some("innerFieldOne"))"#,
-            r#"enter_sel_set (None)"#,
-            r#"leave_sel_set (None)"#,
-            r#"leave_sel (Some("innerFieldOne"))"#,
-            r#"enter_sel (Some("innerFieldTwo"))"#,
-            r#"enter_sel_set (None)"#,
-            r#"leave_sel_set (None)"#,
-            r#"leave_sel (Some("innerFieldTwo"))"#,
-            r#"enter_sel (Some("fragmentSpread"))"#,
-            r#"leave_sel (Some("fragmentSpread"))"#,
-            r#"enter_sel (Some("SomeType"))"#,
-            r#"enter_sel_set (None)"#,
-            r#"enter_sel (Some("someTypeField"))"#,
-            r#"enter_sel_set (None)"#,
-            r#"leave_sel_set (None)"#,
-            r#"leave_sel (Some("someTypeField"))"#,
-            r#"leave_sel_set (None)"#,
-            r#"leave_sel (Some("SomeType"))"#,
-            r#"leave_sel_set (None)"#,
-            r#"leave_sel (Some("fieldB"))"#,
-            r#"leave_sel_set (None)"#,
-            r#"leave_query_def (Some("SomeQuery"))"#,
-            r#"leave_query (None)"#
-        ]
-    );
-
-    Ok(())
-}
-
-#[test]
-fn maps_a_query() -> Result<(), crate::query::ParseError> {
-    let query = crate::parse_query(
-        r#"
+    #[test]
+    fn maps_a_query() -> Result<(), crate::query::ParseError> {
+        let query = crate::parse_query(
+            r#"
         query {
             someField
             another { ...withFragment @directive }
         }
     "#,
-    )?;
-    struct TestMap {}
-    impl visit::Fold for TestMap {
-        type Output = String;
-        fn merge(&mut self, parent: String, child: &String) -> String {
-            format!("{}\n{}", parent, child)
+        )?;
+        struct TestMap {}
+        impl visit::Fold for TestMap {
+            type Output = String;
+            fn merge(&mut self, parent: String, child: &String) -> String {
+                format!("{}\n{}", parent, child)
+            }
         }
-    }
-    impl Fold for TestMap {
-        fn query<'a>(&mut self, _: &Document<'a>, stack: &[Self::Output]) -> Self::Output {
-            format!("{}query", "  ".repeat(stack.len()))
+        impl Fold for TestMap {
+            fn query<'a>(&mut self, _: &Document<'a>, stack: &[Self::Output]) -> Self::Output {
+                format!("{}query", "  ".repeat(stack.len()))
+            }
+            fn query_def<'a>(
+                &mut self,
+                _: &Definition<'a>,
+                stack: &[Self::Output],
+            ) -> Self::Output {
+                format!("{}query_def", "  ".repeat(stack.len()))
+            }
+            fn sel_set<'a>(
+                &mut self,
+                _: &SelectionSet<'a>,
+                stack: &[Self::Output],
+            ) -> Self::Output {
+                format!("{}sel_set", "  ".repeat(stack.len()))
+            }
+            fn sel<'a>(&mut self, _: &Selection<'a>, stack: &[Self::Output]) -> Self::Output {
+                format!("{}sel", "  ".repeat(stack.len()))
+            }
         }
-        fn query_def<'a>(&mut self, _: &Definition<'a>, stack: &[Self::Output]) -> Self::Output {
-            format!("{}query_def", "  ".repeat(stack.len()))
-        }
-        fn sel_set<'a>(&mut self, _: &SelectionSet<'a>, stack: &[Self::Output]) -> Self::Output {
-            format!("{}sel_set", "  ".repeat(stack.len()))
-        }
-        fn sel<'a>(&mut self, _: &Selection<'a>, stack: &[Self::Output]) -> Self::Output {
-            format!("{}sel", "  ".repeat(stack.len()))
-        }
-    }
 
-    let tx = query.fold(TestMap {});
-    pretty_assertions::assert_eq!(
-        tx.output,
-        Some(String::from(
-            r#"query
+        let tx = query.fold(TestMap {});
+        pretty_assertions::assert_eq!(
+            tx.output,
+            Some(String::from(
+                r#"query
   query_def
     sel_set
       sel
@@ -234,7 +248,8 @@ fn maps_a_query() -> Result<(), crate::query::ParseError> {
       sel
         sel_set
           sel"#
-        ))
-    );
-    Ok(())
+            ))
+        );
+        Ok(())
+    }
 }

--- a/graphql-parser/src/schema/grammar.rs
+++ b/graphql-parser/src/schema/grammar.rs
@@ -592,7 +592,7 @@ pub fn parse_schema(s: &str) -> Result<Document, ParseError> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::parse_schema;
     use super::{Definition, Document, SchemaDefinition};
     use crate::position::Pos;

--- a/graphql-parser/src/schema/visit.rs
+++ b/graphql-parser/src/schema/visit.rs
@@ -59,10 +59,10 @@ impl<F: Fold> SchemaVisitor for visit::Folding<F> {
 pub trait Node {
     fn accept<V: SchemaVisitor>(&self, visitor: &mut V);
 
-    fn fold<F: Fold>(&self, fold: F) -> visit::Folding<F> {
+    fn fold<F: Fold>(&self, fold: F) -> Option<F::Output> {
         let mut folding = visit::Folding::new(fold);
         self.accept(&mut folding);
-        folding
+        folding.output
     }
 }
 

--- a/graphql-parser/src/schema/visit.rs
+++ b/graphql-parser/src/schema/visit.rs
@@ -4,7 +4,7 @@ use crate::query::Node as QueryNode;
 use crate::{visit, visit_each};
 
 #[allow(unused_variables)]
-pub trait SchemaVisitor: query::QueryVisitor {
+pub trait Visitor: query::Visitor {
     fn enter_schema<'a>(&mut self, doc: &Document<'a>) {}
     fn enter_schema_def<'a>(&mut self, def: &Definition<'a>) {}
     fn enter_field<'a>(&mut self, field: &Field<'a>) {}
@@ -27,7 +27,7 @@ pub trait Fold: query::Fold {
     ) -> Self::Output;
 }
 
-impl<F: Fold> SchemaVisitor for visit::Folding<F> {
+impl<F: Fold> Visitor for visit::Folding<F> {
     fn enter_schema<'a>(&mut self, doc: &Document<'a>) {
         self.stack.push(self.fold.schema(doc, &self.stack));
     }
@@ -57,7 +57,7 @@ impl<F: Fold> SchemaVisitor for visit::Folding<F> {
 
 #[allow(unused_variables)]
 pub trait Node {
-    fn accept<V: SchemaVisitor>(&self, visitor: &mut V);
+    fn accept<V: Visitor>(&self, visitor: &mut V);
 
     fn fold<F: Fold>(&self, fold: F) -> Option<F::Output> {
         let mut folding = visit::Folding::new(fold);
@@ -67,7 +67,7 @@ pub trait Node {
 }
 
 impl<'a> Node for Document<'a> {
-    fn accept<V: SchemaVisitor>(&self, visitor: &mut V) {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
         visitor.enter_schema(self);
         visit_each!(visitor: self.definitions);
         visitor.leave_schema(self);
@@ -75,7 +75,7 @@ impl<'a> Node for Document<'a> {
 }
 
 impl<'a> Node for Definition<'a> {
-    fn accept<V: SchemaVisitor>(&self, visitor: &mut V) {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
         visitor.enter_schema_def(self);
         match self {
             Definition::Schema(_) => {}
@@ -90,7 +90,7 @@ impl<'a> Node for Definition<'a> {
 }
 
 impl<'a> Node for TypeDefinition<'a> {
-    fn accept<V: SchemaVisitor>(&self, visitor: &mut V) {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
         match self {
             TypeDefinition::Scalar(_) => {}
             TypeDefinition::Object(o) => visit_each!(visitor: o.fields),
@@ -103,7 +103,7 @@ impl<'a> Node for TypeDefinition<'a> {
 }
 
 impl<'a> Node for TypeExtension<'a> {
-    fn accept<V: SchemaVisitor>(&self, visitor: &mut V) {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
         match self {
             TypeExtension::Scalar(_) => {}
             TypeExtension::Object(o) => visit_each!(visitor: o.fields),
@@ -116,14 +116,14 @@ impl<'a> Node for TypeExtension<'a> {
 }
 
 impl<'a> Node for Field<'a> {
-    fn accept<V: SchemaVisitor>(&self, visitor: &mut V) {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
         visitor.enter_field(self);
         visitor.leave_field(self);
     }
 }
 
 impl<'a> Node for InputValue<'a> {
-    fn accept<V: SchemaVisitor>(&self, visitor: &mut V) {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
         visitor.enter_input_value(self);
         visitor.leave_input_value(self);
     }

--- a/graphql-parser/src/schema/visit.rs
+++ b/graphql-parser/src/schema/visit.rs
@@ -59,11 +59,7 @@ impl<F: Fold> Visitor for visit::Folding<F> {
 pub trait Node {
     fn accept<V: Visitor>(&self, visitor: &mut V);
     fn fold<F: Fold>(&self, fold: F) -> visit::Folding<F> {
-        let mut folding = visit::Folding {
-            stack: vec![],
-            fold,
-            output: None,
-        };
+        let mut folding = visit::Folding::new(fold);
         self.accept(&mut folding);
         folding
     }

--- a/graphql-parser/src/tokenizer.rs
+++ b/graphql-parser/src/tokenizer.rs
@@ -325,7 +325,7 @@ impl<'a> fmt::Display for Token<'a> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::Kind::*;
     use super::{Kind, TokenStream};
     use combine::easy::Error;

--- a/graphql-parser/src/visit.rs
+++ b/graphql-parser/src/visit.rs
@@ -3,7 +3,7 @@
 /// This trait is extended by query::Map and schema::Map, which add methods to define the
 /// projection from AST nodes to the map's output type.
 #[allow(unused_variables)]
-pub trait Map {
+pub trait Fold {
     type Output;
 
     /// Merge a child output node into a parent output node.
@@ -18,20 +18,20 @@ pub trait Map {
 
 /// The output of a call to `map` is a Mappping
 #[derive(Debug)]
-pub struct Mapping<M: Map> {
+pub struct Folding<F: Fold> {
     /// The stack only contains elements while the map operation is in progress.
-    /// Specifically, it holds output nodes nodes for every ancestor of the
+    /// Specifically, it holds output nodes for every ancestor of the
     /// current node, and is passed to the projection functions.
-    pub stack: Vec<M::Output>,
+    pub stack: Vec<F::Output>,
 
     /// The map being applied.
-    pub map: M,
+    pub fold: F,
 
     /// The root output node.
-    pub output: Option<M::Output>,
+    pub output: Option<F::Output>,
 }
 
-impl<M: Map> Mapping<M> {
+impl<F: Fold> Folding<F> {
     pub fn pop(&mut self) {
         self.output = self.stack.pop();
         if self.stack.is_empty() {
@@ -39,7 +39,7 @@ impl<M: Map> Mapping<M> {
         }
         if let Some(ref child) = self.output {
             let parent = self.stack.pop().unwrap();
-            self.stack.push(self.map.merge(parent, child));
+            self.stack.push(self.fold.merge(parent, child));
         }
     }
 }

--- a/graphql-parser/src/visit.rs
+++ b/graphql-parser/src/visit.rs
@@ -1,6 +1,6 @@
-/// The Map trait describes how to convert one tree shape into another (possibly) tree shape.
+/// The [Fold] trait describes how to convert one tree shape into another (possibly) tree shape.
 ///
-/// This trait is extended by query::Map and schema::Map, which add methods to define the
+/// This trait is extended by [crate::query::Fold] and [crate::schema::Fold], which add methods to define the
 /// projection from AST nodes to the map's output type.
 #[allow(unused_variables)]
 pub trait Fold {
@@ -16,7 +16,7 @@ pub trait Fold {
     }
 }
 
-/// The output of a call to `map` is a Mappping
+/// The output of a call to `fold` is a Folding
 #[derive(Debug)]
 pub struct Folding<F: Fold> {
     /// The stack only contains elements while the map operation is in progress.
@@ -32,6 +32,14 @@ pub struct Folding<F: Fold> {
 }
 
 impl<F: Fold> Folding<F> {
+    pub fn new(fold: F) -> Self {
+        Self {
+            stack: vec![],
+            fold,
+            output: None,
+        }
+    }
+
     pub fn pop(&mut self) {
         self.output = self.stack.pop();
         if self.stack.is_empty() {

--- a/graphql-parser/tests/helpers.rs
+++ b/graphql-parser/tests/helpers.rs
@@ -83,7 +83,7 @@ macro_rules! print {
     };
 }
 
-impl query::Visitor for Print {
+impl query::QueryVisitor for Print {
     print!(enter_query query::Document);
     print!(leave_query query::Document);
     print!(enter_query_def query::Definition);
@@ -94,7 +94,7 @@ impl query::Visitor for Print {
     print!(leave_sel query::Selection);
 }
 
-impl schema::Visitor for Print {
+impl schema::SchemaVisitor for Print {
     print!(enter_schema schema::Document);
     print!(enter_schema_def schema::Definition);
     print!(enter_field schema::Field);

--- a/graphql-parser/tests/helpers.rs
+++ b/graphql-parser/tests/helpers.rs
@@ -83,7 +83,7 @@ macro_rules! print {
     };
 }
 
-impl query::QueryVisitor for Print {
+impl query::Visitor for Print {
     print!(enter_query query::Document);
     print!(leave_query query::Document);
     print!(enter_query_def query::Definition);
@@ -94,7 +94,7 @@ impl query::QueryVisitor for Print {
     print!(leave_sel query::Selection);
 }
 
-impl schema::SchemaVisitor for Print {
+impl schema::Visitor for Print {
     print!(enter_schema schema::Document);
     print!(enter_schema_def schema::Definition);
     print!(enter_field schema::Field);


### PR DESCRIPTION
- Fix `build.rs` to sort `use` statements
- Rename `Mapping` to `Folding`
- put tests in `mod tests`
- `new()` for `Folding`
- Rename stuff for readability
- return `Option<F::Output>` instead of `Folding<F>`
