### PR TITLE
JSON De/Serialization for `QueryPlan` (compatible with JS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,10 @@ dependencies = [
 [[package]]
 name = "apollo-query-planner"
 version = "0.0.1"
+dependencies = [
+ "serde 1.0.114",
+ "serde_json",
+]
 
 [[package]]
 name = "arrayref"
@@ -2231,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "itoa",
  "ryu",

--- a/query-planner/Cargo.toml
+++ b/query-planner/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1.0.114", features = ["derive"] }
+serde_json = "1.0.56"

--- a/query-planner/src/model.rs
+++ b/query-planner/src/model.rs
@@ -12,7 +12,7 @@ use std::fmt;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(from = "QueryPlanSerde", into = "QueryPlanSerde")]
 pub struct QueryPlan {
-    node: Option<PlanNode>,
+    pub node: Option<PlanNode>,
 }
 
 impl From<QueryPlanSerde> for QueryPlan {

--- a/query-planner/src/model.rs
+++ b/query-planner/src/model.rs
@@ -6,50 +6,77 @@
 //! execute a query plan. Furthermore, within a [Field] or [InlineFragment], we only need
 //! names, aliases, type conditions, and recurively sub [SelectionSet]s.
 
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::fmt;
 
 #[derive(Debug, PartialEq)]
 pub struct QueryPlan(pub Option<PlanNode>);
 
-#[derive(Debug, PartialEq)]
-pub enum PlanNode {
-    Sequence(Vec<PlanNode>),
-    Parallel(Vec<PlanNode>),
-    Fetch(FetchNode),
-    Flatten {
-        path: Vec<ResponsePathElement>,
-        node: Box<PlanNode>,
-    },
+impl QueryPlan {
+    pub fn into_json(self) -> Value {
+        serde_json::to_value(QueryPlanSerde::QueryPlan { node: self.0 }).unwrap()
+    }
+
+    pub fn from_json(value: Value) -> serde_json::Result<QueryPlan> {
+        serde_json::from_value::<QueryPlanSerde>(value)
+            .map(|QueryPlanSerde::QueryPlan { node }| QueryPlan(node))
+    }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase", tag = "kind")]
+pub enum PlanNode {
+    Sequence { nodes: Vec<PlanNode> },
+    Parallel { nodes: Vec<PlanNode> },
+    Fetch(FetchNode),
+    Flatten(FlattenNode),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FetchNode {
     pub service_name: String,
     pub variable_usages: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<SelectionSet>,
     pub operation: GraphQLDocument,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FlattenNode {
+    pub path: Vec<ResponsePathElement>,
+    pub node: Box<PlanNode>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase", tag = "kind")]
 pub enum Selection {
     Field(Field),
     InlineFragment(InlineFragment),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Field {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
     pub name: String,
-    pub selection_set: SelectionSet,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selections: Option<SelectionSet>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InlineFragment {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub type_condition: Option<String>,
-    pub selection_set: SelectionSet,
+    pub selections: SelectionSet,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum ResponsePathElement {
     Field(String),
     Idx(u32),
@@ -66,3 +93,286 @@ impl fmt::Display for ResponsePathElement {
 
 pub type SelectionSet = Vec<Selection>;
 pub type GraphQLDocument = String;
+
+/// Hacking Json Serde to match JS.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase", tag = "kind")]
+enum QueryPlanSerde {
+    QueryPlan { node: Option<PlanNode> },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn qp_json_string() -> &'static str {
+        r#"
+         {
+          "kind": "QueryPlan",
+          "node": {
+            "kind": "Sequence",
+            "nodes": [
+              {
+                "kind": "Fetch",
+                "serviceName": "product",
+                "variableUsages": [],
+                "operation": "{topProducts{__typename ...on Book{__typename isbn}...on Furniture{name}}product(upc:\"1\"){__typename ...on Book{__typename isbn}...on Furniture{name}}}"
+              },
+              {
+                "kind": "Parallel",
+                "nodes": [
+                  {
+                    "kind": "Sequence",
+                    "nodes": [
+                      {
+                        "kind": "Flatten",
+                        "path": ["topProducts", "@"],
+                        "node": {
+                          "kind": "Fetch",
+                          "serviceName": "books",
+                          "requires": [
+                            {
+                              "kind": "InlineFragment",
+                              "typeCondition": "Book",
+                              "selections": [
+                                { "kind": "Field", "name": "__typename" },
+                                { "kind": "Field", "name": "isbn" }
+                              ]
+                            }
+                          ],
+                          "variableUsages": [],
+                          "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+                        }
+                      },
+                      {
+                        "kind": "Flatten",
+                        "path": ["topProducts", "@"],
+                        "node": {
+                          "kind": "Fetch",
+                          "serviceName": "product",
+                          "requires": [
+                            {
+                              "kind": "InlineFragment",
+                              "typeCondition": "Book",
+                              "selections": [
+                                { "kind": "Field", "name": "__typename" },
+                                { "kind": "Field", "name": "isbn" },
+                                { "kind": "Field", "name": "title" },
+                                { "kind": "Field", "name": "year" }
+                              ]
+                            }
+                          ],
+                          "variableUsages": [],
+                          "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "Sequence",
+                    "nodes": [
+                      {
+                        "kind": "Flatten",
+                        "path": ["product"],
+                        "node": {
+                          "kind": "Fetch",
+                          "serviceName": "books",
+                          "requires": [
+                            {
+                              "kind": "InlineFragment",
+                              "typeCondition": "Book",
+                              "selections": [
+                                { "kind": "Field", "name": "__typename" },
+                                { "kind": "Field", "name": "isbn" }
+                              ]
+                            }
+                          ],
+                          "variableUsages": [],
+                          "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+                        }
+                      },
+                      {
+                        "kind": "Flatten",
+                        "path": ["product"],
+                        "node": {
+                          "kind": "Fetch",
+                          "serviceName": "product",
+                          "requires": [
+                            {
+                              "kind": "InlineFragment",
+                              "typeCondition": "Book",
+                              "selections": [
+                                { "kind": "Field", "name": "__typename" },
+                                { "kind": "Field", "name": "isbn" },
+                                { "kind": "Field", "name": "title" },
+                                { "kind": "Field", "name": "year" }
+                              ]
+                            }
+                          ],
+                          "variableUsages": [],
+                          "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }"#
+    }
+
+    fn query_plan() -> QueryPlan {
+        QueryPlan(Some(PlanNode::Sequence {
+            nodes: vec![
+                PlanNode::Fetch(FetchNode {
+                    service_name: "product".to_owned(),
+                    variable_usages: vec![],
+                    requires: None,
+                    operation: "{topProducts{__typename ...on Book{__typename isbn}...on Furniture{name}}product(upc:\"1\"){__typename ...on Book{__typename isbn}...on Furniture{name}}}".to_owned(),
+                }),
+                PlanNode::Parallel {
+                    nodes: vec![
+                        PlanNode::Sequence {
+                            nodes: vec![
+                                PlanNode::Flatten(FlattenNode {
+                                    path: vec![
+                                        ResponsePathElement::Field("topProducts".to_owned()), ResponsePathElement::Field("@".to_owned())],
+                                    node: Box::new(PlanNode::Fetch(FetchNode {
+                                        service_name: "books".to_owned(),
+                                        variable_usages: vec![],
+                                        requires: Some(vec![
+                                            Selection::InlineFragment(InlineFragment {
+                                                type_condition: Some("Book".to_owned()),
+                                                selections: vec![
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "__typename".to_owned(),
+                                                        selections: None,
+                                                    }),
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "isbn".to_owned(),
+                                                        selections: None,
+                                                    })],
+                                            })]),
+                                        operation: "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}".to_owned(),
+                                    })),
+                                }),
+                                PlanNode::Flatten(FlattenNode {
+                                    path: vec![
+                                        ResponsePathElement::Field("topProducts".to_owned()),
+                                        ResponsePathElement::Field("@".to_owned())],
+                                    node: Box::new(PlanNode::Fetch(FetchNode {
+                                        service_name: "product".to_owned(),
+                                        variable_usages: vec![],
+                                        requires: Some(vec![
+                                            Selection::InlineFragment(InlineFragment {
+                                                type_condition: Some("Book".to_owned()),
+                                                selections: vec![
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "__typename".to_owned(),
+                                                        selections: None,
+                                                    }),
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "isbn".to_owned(),
+                                                        selections: None,
+                                                    }),
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "title".to_owned(),
+                                                        selections: None,
+                                                    }),
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "year".to_owned(),
+                                                        selections: None,
+                                                    })],
+                                            })]),
+                                        operation: "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}".to_owned(),
+                                    })),
+                                })]
+                        },
+                        PlanNode::Sequence {
+                            nodes: vec![
+                                PlanNode::Flatten(FlattenNode {
+                                    path: vec![
+                                        ResponsePathElement::Field("product".to_owned())],
+                                    node: Box::new(PlanNode::Fetch(FetchNode {
+                                        service_name: "books".to_owned(),
+                                        variable_usages: vec![],
+                                        requires: Some(vec![
+                                            Selection::InlineFragment(InlineFragment {
+                                                type_condition: Some("Book".to_owned()),
+                                                selections: vec![
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "__typename".to_owned(),
+                                                        selections: None,
+                                                    }),
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "isbn".to_owned(),
+                                                        selections: None,
+                                                    })],
+                                            })]),
+                                        operation: "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}".to_owned(),
+                                    })),
+                                }),
+                                PlanNode::Flatten(FlattenNode {
+                                    path: vec![
+                                        ResponsePathElement::Field("product".to_owned())],
+                                    node: Box::new(PlanNode::Fetch(FetchNode {
+                                        service_name: "product".to_owned(),
+                                        variable_usages: vec![],
+                                        requires: Some(vec![
+                                            Selection::InlineFragment(InlineFragment {
+                                                type_condition: Some("Book".to_owned()),
+                                                selections: vec![
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "__typename".to_owned(),
+                                                        selections: None,
+                                                    }),
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "isbn".to_owned(),
+                                                        selections: None,
+                                                    }),
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "title".to_owned(),
+                                                        selections: None,
+                                                    }),
+                                                    Selection::Field(Field {
+                                                        alias: None,
+                                                        name: "year".to_owned(),
+                                                        selections: None,
+                                                    })],
+                                            })]),
+                                        operation: "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}".to_owned(),
+                                    })),
+                                })]
+                        }]
+                }]
+        }))
+    }
+
+    #[test]
+    fn query_plan_from_json() {
+        assert_eq!(
+            QueryPlan::from_json(serde_json::from_str::<Value>(qp_json_string()).unwrap()).unwrap(),
+            query_plan()
+        );
+    }
+
+    #[test]
+    fn query_plan_into_json() {
+        assert_eq!(
+            query_plan().into_json(),
+            serde_json::from_str::<Value>(qp_json_string()).unwrap()
+        );
+    }
+}


### PR DESCRIPTION
This PR adds the ability to serialize and deserialize a `QueryPlan` into JSON in the same format as it is on the JS side.
We will use then be able to use the same cucumber tests that we have in apollo-gateway to test the Rust implementation of the query planner.

The PR heavily uses the `serde` and `serde_json` crates, and their provided annotations to to achieve the format compatibility. I had to do some minor changes to the model to support this, nothing that really affects ergonomics (for context, the model code was implemented very recently and when I wrote it then I could have just as easily decided to model it like in this PR, but only happened to not do that).

The only real workaround that I had to add was to create a private alternative, single variant enum (`QueryPlanSerde`) for QueryPlan that will serialize with a `kind` field.