### PR TITLE
Implement query planner tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
 name = "apollo-query-planner"
 version = "0.0.1"
 dependencies = [
+ "cucumber_rust",
  "serde 1.0.114",
  "serde_json",
 ]
@@ -127,8 +128,8 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd3d156917d94862e779f356c5acae312b08fd3121e792c857d7928c8088423"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.7",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -305,6 +306,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbcf92448676f82bb7a334c58bbce8b0d43580fb5362a9d608b18879d12a3d31"
@@ -312,7 +325,7 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.14.2",
 ]
 
 [[package]]
@@ -322,6 +335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -418,7 +440,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -615,8 +637,84 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.7",
+ "syn 1.0.33",
+]
+
+[[package]]
+name = "cucumber_rust"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfc3cfa79845de10304701e8a5b6d1b4d8b7e89b27e7d3a57f4b762e6a9f6dd"
+dependencies = [
+ "clap",
+ "gherkin_rust",
+ "globwalk",
+ "pathdiff",
+ "regex",
+ "shh",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "darling"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "strsim 0.7.0",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
+dependencies = [
+ "darling_core",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac53fa6a3cda160df823a9346442525dcaf1e171999a1cf23e67067e4fd64d4"
+dependencies = [
+ "darling",
+ "derive_builder_core",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0288a23da9333c246bb18c143426074a6ae96747995c5819d2947b64cd942b37"
+dependencies = [
+ "darling",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
 ]
 
 [[package]]
@@ -627,11 +725,20 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.2",
 ]
 
 [[package]]
@@ -727,9 +834,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
  "synstructure",
 ]
 
@@ -909,9 +1016,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -1019,6 +1126,15 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
@@ -1039,10 +1155,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "gherkin_rust"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e246e72427f2a2dadc4a94a7db108b52269538d5c0ea0fe5570a707a78115a5"
+dependencies = [
+ "derive_builder",
+ "pest",
+ "pest_derive",
+ "textwrap",
+]
+
+[[package]]
 name = "gimli"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+
+[[package]]
+name = "globset"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9db17aec586697a93219b19726b5b68307eba92898c34b170857343fe67c99d"
+dependencies = [
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "gloo-timers"
@@ -1111,11 +1262,11 @@ dependencies = [
  "graphql-parser 0.2.3",
  "heck",
  "lazy_static",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
  "serde 1.0.114",
  "serde_json",
- "syn",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -1126,8 +1277,8 @@ checksum = "e1f6b14d5ce549227aa9e649cd9d36d008b91021275a8e0a67d71cef815adc2f"
 dependencies = [
  "failure",
  "graphql_client_codegen",
- "proc-macro2",
- "syn",
+ "proc-macro2 1.0.18",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -1291,6 +1442,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1456,24 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1467,6 +1642,12 @@ dependencies = [
  "generator",
  "scoped-tls",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
@@ -1749,6 +1930,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3bf70094d203e07844da868b634207e71bfab254fe713171fae9a6e751ccf31"
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +1946,49 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
+]
 
 [[package]]
 name = "pin-project"
@@ -1775,9 +2005,9 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -1864,9 +2094,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
  "version_check",
 ]
 
@@ -1876,9 +2106,9 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
  "syn-mid",
  "version_check",
 ]
@@ -1897,11 +2127,20 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "proc-macro2"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
@@ -1921,11 +2160,20 @@ dependencies = [
 
 [[package]]
 name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.18",
 ]
 
 [[package]]
@@ -2094,6 +2342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,9 +2485,9 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -2278,15 +2535,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72377440080fd008550fe9b441e854e43318db116f90181eef92e9ae9aedab48"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.8.0",
+ "digest 0.9.0",
  "fake-simd",
  "opaque-debug",
+]
+
+[[package]]
+name = "shh"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5205eb079ac8be8ec77b7470aff4a050610d42c32819deee362ca414c926d3ab"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2342,6 +2621,12 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+
+[[package]]
+name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
@@ -2365,9 +2650,20 @@ checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -2376,9 +2672,9 @@ version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
@@ -2387,9 +2683,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -2398,10 +2694,10 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
@@ -2480,6 +2776,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "term_size",
  "unicode-width",
 ]
 
@@ -2498,9 +2795,9 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -2604,6 +2901,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,6 +2944,12 @@ name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -2711,6 +3020,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.8",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,9 +3067,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
  "wasm-bindgen-shared",
 ]
 
@@ -2771,7 +3091,7 @@ version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3"
 dependencies = [
- "quote",
+ "quote 1.0.7",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2781,9 +3101,9 @@ version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ name = "apollo-query-planner"
 version = "0.0.1"
 dependencies = [
  "cucumber_rust",
+ "graphql-parser 0.3.0",
  "serde 1.0.114",
  "serde_json",
 ]

--- a/query-planner/Cargo.toml
+++ b/query-planner/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0.56"
 [dev-dependencies]
 cucumber = { package = "cucumber_rust", version = "^0.6.0" } 
 
+# Having this commented out is preventing the cucumber tests from running, but still compiles them. Uncomment to run them.
 # [[test]]
 # name = "cucumber"
 # harness = false # Allows Cucumber to print output instead of libtest

--- a/query-planner/Cargo.toml
+++ b/query-planner/Cargo.toml
@@ -15,6 +15,6 @@ serde_json = "1.0.56"
 [dev-dependencies]
 cucumber = { package = "cucumber_rust", version = "^0.6.0" } 
 
-[[test]]
-name = "cucumber"
-harness = false # Allows Cucumber to print output instead of libtest
+# [[test]]
+# name = "cucumber"
+# harness = false # Allows Cucumber to print output instead of libtest

--- a/query-planner/Cargo.toml
+++ b/query-planner/Cargo.toml
@@ -10,3 +10,10 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
+
+[dev-dependencies]
+cucumber = { package = "cucumber_rust", version = "^0.6.0" } 
+
+[[test]]
+name = "cucumber"
+harness = false # Allows Cucumber to print output instead of libtest

--- a/query-planner/Cargo.toml
+++ b/query-planner/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+graphql-parser = { path = "../graphql-parser" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
 

--- a/query-planner/tests/build-query-plan.feature
+++ b/query-planner/tests/build-query-plan.feature
@@ -1222,3 +1222,453 @@ Scenario: should not confuse union types with overlapping field names
 #       }
 #     }
 #     """
+
+# Scenario: supports basic, single-service mutation
+#   Given query
+#   """
+#   mutation Login($username: String!, $password: String!) {
+#     login(username: $username, password: $password) {
+#       id
+#     }
+#   }
+#   """
+#   Then query plan
+#   """
+#   {
+#     "kind": "QueryPlan",
+#     "node": {
+#       "kind": "Fetch",
+#       "serviceName": "accounts",
+#       "variableUsages": [
+#         "username",
+#         "password"
+#       ],
+#       "operation": "mutation($username:String!$password:String!){login(username:$username password:$password){id}}"
+#     }
+#   }
+#   """
+
+# ported from: https://github.com/apollographql/apollo-server/blob/main/packages/apollo-gateway/src/__tests__/integration/mutations.test.ts#L13
+Scenario: supports mutations with a cross-service request
+  Given query
+  """
+  mutation Login($username: String!, $password: String!) {
+    login(username: $username, password: $password) {
+      reviews {
+        product {
+          upc
+        }
+      }
+    }
+  }
+  """
+  Then query plan
+  """
+  {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Sequence",
+      "nodes": [
+        {
+          "kind": "Fetch",
+          "serviceName": "accounts",
+          "variableUsages": [
+            "username",
+            "password"
+          ],
+          "operation": "mutation($username:String!$password:String!){login(username:$username password:$password){__typename id}}"
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "User",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "id"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+          }
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login",
+            "reviews",
+            "@",
+            "product"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "Book",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "isbn"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}"
+          }
+        }
+      ]
+    }
+  }
+  """
+
+# ported from: https://github.com/apollographql/apollo-server/blob/main/packages/apollo-gateway/src/__tests__/integration/mutations.test.ts#L48
+Scenario: returning across service boundaries
+  Given query
+  """
+  mutation Review($upc: String!, $body: String!) {
+    reviewProduct(upc: $upc, body: $body) {
+      ... on Furniture {
+        name
+      }
+    }
+  }
+  """
+  Then query plan
+  """
+  {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Sequence",
+      "nodes": [
+        {
+          "kind": "Fetch",
+          "serviceName": "reviews",
+          "variableUsages": [
+            "upc",
+            "body"
+          ],
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{__typename upc}}}"
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "reviewProduct"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "Furniture",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "upc"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}"
+          }
+        }
+      ]
+    }
+  }
+  """
+
+# ported from: https://github.com/apollographql/apollo-server/blob/main/packages/apollo-gateway/src/__tests__/integration/mutations.test.ts#L75
+Scenario: supports multiple root mutations
+  Given query
+  """
+  mutation LoginAndReview(
+    $username: String!
+    $password: String!
+    $upc: String!
+    $body: String!
+  ) {
+    login(username: $username, password: $password) {
+      reviews {
+        product {
+          upc
+        }
+      }
+    }
+    reviewProduct(upc: $upc, body: $body) {
+      ... on Furniture {
+        name
+      }
+    }
+  }
+  """
+  Then query plan
+  """
+  {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Sequence",
+      "nodes": [
+        {
+          "kind": "Fetch",
+          "serviceName": "accounts",
+          "variableUsages": [
+            "username",
+            "password"
+          ],
+          "operation": "mutation($username:String!$password:String!){login(username:$username password:$password){__typename id}}"
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "User",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "id"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+          }
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login",
+            "reviews",
+            "@",
+            "product"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "Book",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "isbn"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}"
+          }
+        },
+        {
+          "kind": "Fetch",
+          "serviceName": "reviews",
+          "variableUsages": [
+            "upc",
+            "body"
+          ],
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{__typename upc}}}"
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "reviewProduct"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "Furniture",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "upc"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}"
+          }
+        }
+      ]
+    }
+  }
+  """
+
+# ported from: https://github.com/apollographql/apollo-server/blob/main/packages/apollo-gateway/src/__tests__/integration/mutations.test.ts#L136
+Scenario: multiple root mutations with correct service order
+  Given query
+  """
+  mutation LoginAndReview(
+    $upc: String!
+    $body: String!
+    $updatedReview: UpdateReviewInput!
+    $username: String!
+    $password: String!
+    $reviewId: ID!
+  ) {
+    reviewProduct(upc: $upc, body: $body) {
+      ... on Furniture {
+        upc
+      }
+    }
+    updateReview(review: $updatedReview) {
+      id
+      body
+    }
+    login(username: $username, password: $password) {
+      reviews {
+        product {
+          upc
+        }
+      }
+    }
+    deleteReview(id: $reviewId)
+  }
+  """
+  Then query plan
+  """
+  {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Sequence",
+      "nodes": [
+        {
+          "kind": "Fetch",
+          "serviceName": "reviews",
+          "variableUsages": [
+            "upc",
+            "body",
+            "updatedReview"
+          ],
+          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
+        },
+        {
+          "kind": "Fetch",
+          "serviceName": "accounts",
+          "variableUsages": [
+            "username",
+            "password"
+          ],
+          "operation": "mutation($username:String!$password:String!){login(username:$username password:$password){__typename id}}"
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "User",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "id"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+          }
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login",
+            "reviews",
+            "@",
+            "product"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "Book",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "isbn"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}"
+          }
+        },
+        {
+          "kind": "Fetch",
+          "serviceName": "reviews",
+          "variableUsages": [
+            "reviewId"
+          ],
+          "operation": "mutation($reviewId:ID!){deleteReview(id:$reviewId)}"
+        }
+      ]
+    }
+  }
+  """

--- a/query-planner/tests/build-query-plan.feature
+++ b/query-planner/tests/build-query-plan.feature
@@ -1,0 +1,1224 @@
+Feature: Build Query Plan
+
+Scenario: should not confuse union types with overlapping field names
+  Given query
+    """
+    query {
+      body {
+        ...on Image {
+          attributes {
+            url
+          }
+        }
+        ...on Text {
+          attributes {
+            bold
+            text
+          }
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "documents",
+        "variableUsages": [],
+        "operation": "{body{__typename ...on Image{attributes{url}}...on Text{attributes{bold text}}}}"
+      }
+    }
+    """
+
+# Scenario: should use a single fetch when requesting a root field from one service
+#   Given query
+#     """
+#     query {
+#       me {
+#         name
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Fetch",
+#         "serviceName": "accounts",
+#         "variableUsages": [],
+#         "operation": "{me{name}}"
+#       }
+#     }
+#     """
+
+# Scenario: should use two independent fetches when requesting root fields from two services
+#   Given query
+#     """
+#     query {
+#       me {
+#         name
+#       }
+#       topProducts {
+#         name
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Parallel",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "accounts",
+#             "variableUsages": [],
+#             "operation": "{me{name}}"
+#           },
+#           {
+#             "kind": "Sequence",
+#             "nodes": [
+#               {
+#                 "kind": "Fetch",
+#                 "serviceName": "product",
+#                 "variableUsages": [],
+#                 "operation": "{topProducts{__typename ...on Book{__typename isbn}...on Furniture{name}}}"
+#               },
+#               {
+#                 "kind": "Flatten",
+#                 "path": ["topProducts", "@"],
+#                 "node": {
+#                   "kind": "Fetch",
+#                   "serviceName": "books",
+#                   "requires": [
+#                     {
+#                       "kind": "InlineFragment",
+#                       "typeCondition": "Book",
+#                       "selections": [
+#                         { "kind": "Field", "name": "__typename" },
+#                         { "kind": "Field", "name": "isbn" }
+#                       ]
+#                     }
+#                   ],
+#                   "variableUsages": [],
+#                   "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+#                 }
+#               },
+#               {
+#                 "kind": "Flatten",
+#                 "path": ["topProducts", "@"],
+#                 "node": {
+#                   "kind": "Fetch",
+#                   "serviceName": "product",
+#                   "requires": [
+#                     {
+#                       "kind": "InlineFragment",
+#                       "typeCondition": "Book",
+#                       "selections": [
+#                         { "kind": "Field", "name": "__typename" },
+#                         { "kind": "Field", "name": "isbn" },
+#                         { "kind": "Field", "name": "title" },
+#                         { "kind": "Field", "name": "year" }
+#                       ]
+#                     }
+#                   ],
+#                   "variableUsages": [],
+#                   "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+#                 }
+#               }
+#             ]
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: should use a single fetch when requesting multiple root fields from the same service
+#   Given query
+#     """
+#     query {
+#       topProducts {
+#         name
+#       }
+#       product(upc: "1") {
+#         name
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "product",
+#             "variableUsages": [],
+#             "operation": "{topProducts{__typename ...on Book{__typename isbn}...on Furniture{name}}product(upc:\"1\"){__typename ...on Book{__typename isbn}...on Furniture{name}}}"
+#           },
+#           {
+#             "kind": "Parallel",
+#             "nodes": [
+#               {
+#                 "kind": "Sequence",
+#                 "nodes": [
+#                   {
+#                     "kind": "Flatten",
+#                     "path": ["topProducts", "@"],
+#                     "node": {
+#                       "kind": "Fetch",
+#                       "serviceName": "books",
+#                       "requires": [
+#                         {
+#                           "kind": "InlineFragment",
+#                           "typeCondition": "Book",
+#                           "selections": [
+#                             { "kind": "Field", "name": "__typename" },
+#                             { "kind": "Field", "name": "isbn" }
+#                           ]
+#                         }
+#                       ],
+#                       "variableUsages": [],
+#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+#                     }
+#                   },
+#                   {
+#                     "kind": "Flatten",
+#                     "path": ["topProducts", "@"],
+#                     "node": {
+#                       "kind": "Fetch",
+#                       "serviceName": "product",
+#                       "requires": [
+#                         {
+#                           "kind": "InlineFragment",
+#                           "typeCondition": "Book",
+#                           "selections": [
+#                             { "kind": "Field", "name": "__typename" },
+#                             { "kind": "Field", "name": "isbn" },
+#                             { "kind": "Field", "name": "title" },
+#                             { "kind": "Field", "name": "year" }
+#                           ]
+#                         }
+#                       ],
+#                       "variableUsages": [],
+#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+#                     }
+#                   }
+#                 ]
+#               },
+#               {
+#                 "kind": "Sequence",
+#                 "nodes": [
+#                   {
+#                     "kind": "Flatten",
+#                     "path": ["product"],
+#                     "node": {
+#                       "kind": "Fetch",
+#                       "serviceName": "books",
+#                       "requires": [
+#                         {
+#                           "kind": "InlineFragment",
+#                           "typeCondition": "Book",
+#                           "selections": [
+#                             { "kind": "Field", "name": "__typename" },
+#                             { "kind": "Field", "name": "isbn" }
+#                           ]
+#                         }
+#                       ],
+#                       "variableUsages": [],
+#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+#                     }
+#                   },
+#                   {
+#                     "kind": "Flatten",
+#                     "path": ["product"],
+#                     "node": {
+#                       "kind": "Fetch",
+#                       "serviceName": "product",
+#                       "requires": [
+#                         {
+#                           "kind": "InlineFragment",
+#                           "typeCondition": "Book",
+#                           "selections": [
+#                             { "kind": "Field", "name": "__typename" },
+#                             { "kind": "Field", "name": "isbn" },
+#                             { "kind": "Field", "name": "title" },
+#                             { "kind": "Field", "name": "year" }
+#                           ]
+#                         }
+#                       ],
+#                       "variableUsages": [],
+#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+#                     }
+#                   }
+#                 ]
+#               }
+#             ]
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: should use a single fetch when requesting relationship subfields from the same service
+#   Given query
+#     """
+#     query {
+#       topReviews {
+#         body
+#         author {
+#           reviews {
+#             body
+#           }
+#         }
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Fetch",
+#         "serviceName": "reviews",
+#         "variableUsages": [],
+#         "operation": "{topReviews{body author{reviews{body}}}}"
+#       }
+#     }
+#     """
+
+# Scenario: should use a single fetch when requesting relationship subfields and provided keys from the same service
+#   Given query
+#     """
+#     query {
+#       topReviews {
+#         body
+#         author {
+#           id
+#           reviews {
+#             body
+#           }
+#         }
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Fetch",
+#         "serviceName": "reviews",
+#         "variableUsages": [],
+#         "operation": "{topReviews{body author{id reviews{body}}}}"
+#       }
+#     }
+#     """
+
+# Scenario: when requesting an extension field from another service, it should add the field's representation requirements to the parent selection set and use a dependent fetch
+#   Given query
+#   """
+#   query {
+#     me {
+#       name
+#       reviews {
+#         body
+#       }
+#     }
+#   }
+#   """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "accounts",
+#             "variableUsages": [],
+#             "operation": "{me{name __typename id}}"
+#           },
+#           {
+#             "kind": "Flatten",
+#             "path": ["me"],
+#             "node": {
+#               "kind": "Fetch",
+#               "serviceName": "reviews",
+#               "requires": [
+#                 {
+#                   "kind": "InlineFragment",
+#                   "typeCondition": "User",
+#                   "selections": [
+#                     { "kind": "Field", "name": "__typename" },
+#                     { "kind": "Field", "name": "id" }
+#                   ]
+#                 }
+#               ],
+#               "variableUsages": [],
+#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body}}}}"
+#             }
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: when requesting an extension field from another service, when the parent selection set is empty, should add the field's requirements to the parent selection set and use a dependent fetch
+#   Given query
+#     """
+#     query {
+#       me {
+#         reviews {
+#           body
+#         }
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "accounts",
+#             "variableUsages": [],
+#             "operation": "{me{__typename id}}"
+#           },
+#           {
+#             "kind": "Flatten",
+#             "path": ["me"],
+#             "node": {
+#               "kind": "Fetch",
+#               "serviceName": "reviews",
+#               "requires": [
+#                 {
+#                   "kind": "InlineFragment",
+#                   "typeCondition": "User",
+#                   "selections": [
+#                     { "kind": "Field", "name": "__typename" },
+#                     { "kind": "Field", "name": "id" }
+#                   ]
+#                 }
+#               ],
+#               "variableUsages": [],
+#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body}}}}"
+#             }
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: when requesting an extension field from another service, should only add requirements once
+#   Given query
+#     """
+#     query {
+#       me {
+#         reviews {
+#           body
+#         }
+#         numberOfReviews
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "accounts",
+#             "variableUsages": [],
+#             "operation": "{me{__typename id}}"
+#           },
+#           {
+#             "kind": "Flatten",
+#             "path": ["me"],
+#             "node": {
+#               "kind": "Fetch",
+#               "serviceName": "reviews",
+#               "requires": [
+#                 {
+#                   "kind": "InlineFragment",
+#                   "typeCondition": "User",
+#                   "selections": [
+#                     { "kind": "Field", "name": "__typename" },
+#                     { "kind": "Field", "name": "id" }
+#                   ]
+#                 }
+#               ],
+#               "variableUsages": [],
+#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body}numberOfReviews}}}"
+#             }
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: when requesting a composite field with subfields from another service, it should add key fields to the parent selection set and use a dependent fetch
+#   Given query
+#     """
+#     query {
+#       topReviews {
+#         body
+#         author {
+#           name
+#         }
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "reviews",
+#             "variableUsages": [],
+#             "operation": "{topReviews{body author{__typename id}}}"
+#           },
+#           {
+#             "kind": "Flatten",
+#             "path": ["topReviews", "@", "author"],
+#             "node": {
+#               "kind": "Fetch",
+#               "serviceName": "accounts",
+#               "requires": [
+#                 {
+#                   "kind": "InlineFragment",
+#                   "typeCondition": "User",
+#                   "selections": [
+#                     { "kind": "Field", "name": "__typename" },
+#                     { "kind": "Field", "name": "id" }
+#                   ]
+#                 }
+#               ],
+#               "variableUsages": [],
+#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}"
+#             }
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: when requesting a composite field with subfields from another service, when requesting a field defined in another service which requires a field in the base service, it should add the field provided by base service in first Fetch
+#   Given query
+#     """
+#     query {
+#       topCars {
+#         retailPrice
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "product",
+#             "variableUsages": [],
+#             "operation": "{topCars{__typename id price}}"
+#           },
+#           {
+#             "kind": "Flatten",
+#             "path": ["topCars", "@"],
+#             "node": {
+#               "kind": "Fetch",
+#               "serviceName": "reviews",
+#               "requires": [
+#                 {
+#                   "kind": "InlineFragment",
+#                   "typeCondition": "Car",
+#                   "selections": [
+#                     { "kind": "Field", "name": "__typename" },
+#                     { "kind": "Field", "name": "id" },
+#                     { "kind": "Field", "name": "price" }
+#                   ]
+#                 }
+#               ],
+#               "variableUsages": [],
+#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Car{retailPrice}}}"
+#             }
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: when requesting a composite field with subfields from another service, when the parent selection set is empty, it should add key fields to the parent selection set and use a dependent fetch
+#   Given query
+#     """
+#     query {
+#       topReviews {
+#         author {
+#           name
+#         }
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "reviews",
+#             "variableUsages": [],
+#             "operation": "{topReviews{author{__typename id}}}"
+#           },
+#           {
+#             "kind": "Flatten",
+#             "path": ["topReviews", "@", "author"],
+#             "node": {
+#               "kind": "Fetch",
+#               "serviceName": "accounts",
+#               "requires": [
+#                 {
+#                   "kind": "InlineFragment",
+#                   "typeCondition": "User",
+#                   "selections": [
+#                     { "kind": "Field", "name": "__typename" },
+#                     { "kind": "Field", "name": "id" }
+#                   ]
+#                 }
+#               ],
+#               "variableUsages": [],
+#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}"
+#             }
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: when requesting a relationship field with extension subfields from a different service, it should first fetch the object using a key from the base service and then pass through the requirements
+#   Given query
+#     """
+#     query {
+#       topReviews {
+#         author {
+#           birthDate
+#         }
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "reviews",
+#             "variableUsages": [],
+#             "operation": "{topReviews{author{__typename id}}}"
+#           },
+#           {
+#             "kind": "Flatten",
+#             "path": ["topReviews", "@", "author"],
+#             "node": {
+#               "kind": "Fetch",
+#               "serviceName": "accounts",
+#               "requires": [
+#                 {
+#                   "kind": "InlineFragment",
+#                   "typeCondition": "User",
+#                   "selections": [
+#                     { "kind": "Field", "name": "__typename" },
+#                     { "kind": "Field", "name": "id" }
+#                   ]
+#                 }
+#               ],
+#               "variableUsages": [],
+#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{birthDate}}}"
+#             }
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: for abstract types, it should add __typename when fetching objects of an interface type from a service
+#   Given query
+#     """
+#     query {
+#       topProducts {
+#         price
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Fetch",
+#         "serviceName": "product",
+#         "variableUsages": [],
+#         "operation": "{topProducts{__typename ...on Book{price}...on Furniture{price}}}"
+#       }
+#     }
+#     """
+
+# Scenario: should break up when traversing an extension field on an interface type from a service
+#   Given query
+#     """
+#     query {
+#       topProducts {
+#         price
+#         reviews {
+#           body
+#         }
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "product",
+#             "variableUsages": [],
+#             "operation": "{topProducts{__typename ...on Book{price __typename isbn}...on Furniture{price __typename upc}}}"
+#           },
+#           {
+#             "kind": "Flatten",
+#             "path": ["topProducts", "@"],
+#             "node": {
+#               "kind": "Fetch",
+#               "serviceName": "reviews",
+#               "requires": [
+#                 {
+#                   "kind": "InlineFragment",
+#                   "typeCondition": "Book",
+#                   "selections": [
+#                     { "kind": "Field", "name": "__typename" },
+#                     { "kind": "Field", "name": "isbn" }
+#                   ]
+#                 },
+#                 {
+#                   "kind": "InlineFragment",
+#                   "typeCondition": "Furniture",
+#                   "selections": [
+#                     { "kind": "Field", "name": "__typename" },
+#                     { "kind": "Field", "name": "upc" }
+#                   ]
+#                 }
+#               ],
+#               "variableUsages": [],
+#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{body}}...on Furniture{reviews{body}}}}"
+#             }
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: interface fragments should expand into possible types only
+#   Given query
+#     """
+#     query {
+#       books {
+#         ... on Product {
+#           name
+#           ... on Furniture {
+#             upc
+#           }
+#         }
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "books",
+#             "variableUsages": [],
+#             "operation": "{books{__typename isbn title year}}"
+#           },
+#           {
+#             "kind": "Flatten",
+#             "path": ["books", "@"],
+#             "node": {
+#               "kind": "Fetch",
+#               "serviceName": "product",
+#               "requires": [
+#                 {
+#                   "kind": "InlineFragment",
+#                   "typeCondition": "Book",
+#                   "selections": [
+#                     { "kind": "Field", "name": "__typename" },
+#                     { "kind": "Field", "name": "isbn" },
+#                     { "kind": "Field", "name": "title" },
+#                     { "kind": "Field", "name": "year" }
+#                   ]
+#                 }
+#               ],
+#               "variableUsages": [],
+#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+#             }
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: interface inside interface should expand into possible types only
+#   Given query
+#     """
+#     query {
+#       product(upc: "") {
+#         details {
+#           country
+#         }
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Fetch",
+#         "serviceName": "product",
+#         "variableUsages": [],
+#         "operation": "{product(upc:\"\"){__typename ...on Book{details{country}}...on Furniture{details{country}}}}"
+#       }
+#     }
+#     """
+
+# Scenario: experimental compression to downstream services should generate fragments internally to downstream requests
+#   Given query
+#     """
+#     query {
+#       topReviews {
+#         body
+#         author
+#         product {
+#           name
+#           price
+#           details {
+#             country
+#           }
+#         }
+#       }
+#     }
+#     """
+#   When using autofragmentization
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "reviews",
+#             "variableUsages": [],
+#             "operation": "{topReviews{...__QueryPlanFragment_1__}}fragment __QueryPlanFragment_1__ on Review{body author product{...__QueryPlanFragment_0__}}fragment __QueryPlanFragment_0__ on Product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}"
+#           },
+#           {
+#             "kind": "Parallel",
+#             "nodes": [
+#               {
+#                 "kind": "Sequence",
+#                 "nodes": [
+#                   {
+#                     "kind": "Flatten",
+#                     "path": ["topReviews", "@", "product"],
+#                     "node": {
+#                       "kind": "Fetch",
+#                       "serviceName": "books",
+#                       "requires": [
+#                         {
+#                           "kind": "InlineFragment",
+#                           "typeCondition": "Book",
+#                           "selections": [
+#                             { "kind": "Field", "name": "__typename" },
+#                             { "kind": "Field", "name": "isbn" }
+#                           ]
+#                         }
+#                       ],
+#                       "variableUsages": [],
+#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+#                     }
+#                   },
+#                   {
+#                     "kind": "Flatten",
+#                     "path": ["topReviews", "@", "product"],
+#                     "node": {
+#                       "kind": "Fetch",
+#                       "serviceName": "product",
+#                       "requires": [
+#                         {
+#                           "kind": "InlineFragment",
+#                           "typeCondition": "Book",
+#                           "selections": [
+#                             { "kind": "Field", "name": "__typename" },
+#                             { "kind": "Field", "name": "isbn" },
+#                             { "kind": "Field", "name": "title" },
+#                             { "kind": "Field", "name": "year" }
+#                           ]
+#                         }
+#                       ],
+#                       "variableUsages": [],
+#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+#                     }
+#                   }
+#                 ]
+#               },
+#               {
+#                 "kind": "Flatten",
+#                 "path": ["topReviews", "@", "product"],
+#                 "node": {
+#                   "kind": "Fetch",
+#                   "serviceName": "product",
+#                   "requires": [
+#                     {
+#                       "kind": "InlineFragment",
+#                       "typeCondition": "Furniture",
+#                       "selections": [
+#                         { "kind": "Field", "name": "__typename" },
+#                         { "kind": "Field", "name": "upc" }
+#                       ]
+#                     },
+#                     {
+#                       "kind": "InlineFragment",
+#                       "typeCondition": "Book",
+#                       "selections": [
+#                         { "kind": "Field", "name": "__typename" },
+#                         { "kind": "Field", "name": "isbn" }
+#                       ]
+#                     }
+#                   ],
+#                   "variableUsages": [],
+#                   "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name price details{country}}...on Book{price details{country}}}}"
+#                 }
+#               }
+#             ]
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: experimental compression to downstream services shouldn't generate fragments for selection sets of length 2 or less
+#   Given query
+#     """
+#     query {
+#       topReviews {
+#         body
+#         author
+#       }
+#     }
+#     """
+#   When using autofragmentization
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Fetch",
+#         "serviceName": "reviews",
+#         "variableUsages": [],
+#         "operation": "{topReviews{body author}}"
+#       }
+#     }
+#     """
+
+# Scenario: experimental compression to downstream services should generate fragments for selection sets of length 3 or greater
+#   Given query
+#     """
+#     query {
+#       topReviews {
+#         id
+#         body
+#         author
+#       }
+#     }
+#     """
+#   When using autofragmentization
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Fetch",
+#         "serviceName": "reviews",
+#         "variableUsages": [],
+#         "operation": "{topReviews{...__QueryPlanFragment_0__}}fragment __QueryPlanFragment_0__ on Review{id body author}"
+#       }
+#     }
+#     """
+
+# Scenario: experimental compression to downstream services should generate fragments correctly when aliases are used
+#   Given query
+#     """
+#     query {
+#       reviews: topReviews {
+#         content: body
+#         author
+#         product {
+#           name
+#           cost: price
+#           details {
+#             origin: country
+#           }
+#         }
+#       }
+#     }
+#     """
+#   When using autofragmentization
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Sequence",
+#         "nodes": [
+#           {
+#             "kind": "Fetch",
+#             "serviceName": "reviews",
+#             "variableUsages": [],
+#             "operation": "{reviews:topReviews{...__QueryPlanFragment_1__}}fragment __QueryPlanFragment_1__ on Review{content:body author product{...__QueryPlanFragment_0__}}fragment __QueryPlanFragment_0__ on Product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}"
+#           },
+#           {
+#             "kind": "Parallel",
+#             "nodes": [
+#               {
+#                 "kind": "Sequence",
+#                 "nodes": [
+#                   {
+#                     "kind": "Flatten",
+#                     "path": ["reviews", "@", "product"],
+#                     "node": {
+#                       "kind": "Fetch",
+#                       "serviceName": "books",
+#                       "requires": [
+#                         {
+#                           "kind": "InlineFragment",
+#                           "typeCondition": "Book",
+#                           "selections": [
+#                             { "kind": "Field", "name": "__typename" },
+#                             { "kind": "Field", "name": "isbn" }
+#                           ]
+#                         }
+#                       ],
+#                       "variableUsages": [],
+#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+#                     }
+#                   },
+#                   {
+#                     "kind": "Flatten",
+#                     "path": ["reviews", "@", "product"],
+#                     "node": {
+#                       "kind": "Fetch",
+#                       "serviceName": "product",
+#                       "requires": [
+#                         {
+#                           "kind": "InlineFragment",
+#                           "typeCondition": "Book",
+#                           "selections": [
+#                             { "kind": "Field", "name": "__typename" },
+#                             { "kind": "Field", "name": "isbn" },
+#                             { "kind": "Field", "name": "title" },
+#                             { "kind": "Field", "name": "year" }
+#                           ]
+#                         }
+#                       ],
+#                       "variableUsages": [],
+#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+#                     }
+#                   }
+#                 ]
+#               },
+#               {
+#                 "kind": "Flatten",
+#                 "path": ["reviews", "@", "product"],
+#                 "node": {
+#                   "kind": "Fetch",
+#                   "serviceName": "product",
+#                   "requires": [
+#                     {
+#                       "kind": "InlineFragment",
+#                       "typeCondition": "Furniture",
+#                       "selections": [
+#                         { "kind": "Field", "name": "__typename" },
+#                         { "kind": "Field", "name": "upc" }
+#                       ]
+#                     },
+#                     {
+#                       "kind": "InlineFragment",
+#                       "typeCondition": "Book",
+#                       "selections": [
+#                         { "kind": "Field", "name": "__typename" },
+#                         { "kind": "Field", "name": "isbn" }
+#                       ]
+#                     }
+#                   ],
+#                   "variableUsages": [],
+#                   "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name cost:price details{origin:country}}...on Book{cost:price details{origin:country}}}}"
+#                 }
+#               }
+#             ]
+#           }
+#         ]
+#       }
+#     }
+#     """
+
+# Scenario: should properly expand nested unions with inline fragments
+#   Given query
+#     """
+#     query {
+#       body {
+#         ... on Image {
+#           ... on Body {
+#             ... on Image {
+#               attributes {
+#                 url
+#               }
+#             }
+#             ... on Text {
+#               attributes {
+#                 bold
+#                 text
+#               }
+#             }
+#           }
+#         }
+#         ... on Text {
+#           attributes {
+#             bold
+#           }
+#         }
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Fetch",
+#         "serviceName": "documents",
+#         "variableUsages": [],
+#         "operation": "{body{__typename ...on Image{attributes{url}}...on Text{attributes{bold}}}}"
+#       }
+#     }
+#     """
+
+# Scenario: deduplicates fields / selections regardless of adjacency and type condition nesting for inline fragments
+#   Given query
+#     """
+#     query {
+#       body {
+#         ... on Image {
+#           ... on Text {
+#             attributes {
+#               bold
+#             }
+#           }
+#         }
+#         ... on Body {
+#           ... on Text {
+#             attributes {
+#               bold
+#               text
+#             }
+#           }
+#         }
+#         ... on Text {
+#           attributes {
+#             bold
+#             text
+#           }
+#         }
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Fetch",
+#         "serviceName": "documents",
+#         "variableUsages": [],
+#         "operation": "{body{__typename ...on Text{attributes{bold text}}}}"
+#       }
+#     }
+#     """
+
+# Scenario: deduplicates fields / selections regardless of adjacency and type condition nesting for named fragment spreads
+#   Given query
+#     """
+#     fragment TextFragment on Text {
+#       attributes {
+#         bold
+#         text
+#       }
+#     }
+
+#     query {
+#       body {
+#         ... on Image {
+#           ...TextFragment
+#         }
+#         ... on Body {
+#           ...TextFragment
+#         }
+#         ...TextFragment
+#       }
+#     }
+#     """
+#   Then query plan
+#     """
+#     {
+#       "kind": "QueryPlan",
+#       "node": {
+#         "kind": "Fetch",
+#         "serviceName": "documents",
+#         "variableUsages": [],
+#         "operation": "{body{__typename ...on Text{attributes{bold text}}}}"
+#       }
+#     }
+#     """

--- a/query-planner/tests/build-query-plan.feature
+++ b/query-planner/tests/build-query-plan.feature
@@ -32,1221 +32,1221 @@ Scenario: should not confuse union types with overlapping field names
     }
     """
 
-# Scenario: should use a single fetch when requesting a root field from one service
-#   Given query
-#     """
-#     query {
-#       me {
-#         name
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Fetch",
-#         "serviceName": "accounts",
-#         "variableUsages": [],
-#         "operation": "{me{name}}"
-#       }
-#     }
-#     """
+Scenario: should use a single fetch when requesting a root field from one service
+  Given query
+    """
+    query {
+      me {
+        name
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "accounts",
+        "variableUsages": [],
+        "operation": "{me{name}}"
+      }
+    }
+    """
 
-# Scenario: should use two independent fetches when requesting root fields from two services
-#   Given query
-#     """
-#     query {
-#       me {
-#         name
-#       }
-#       topProducts {
-#         name
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Parallel",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "accounts",
-#             "variableUsages": [],
-#             "operation": "{me{name}}"
-#           },
-#           {
-#             "kind": "Sequence",
-#             "nodes": [
-#               {
-#                 "kind": "Fetch",
-#                 "serviceName": "product",
-#                 "variableUsages": [],
-#                 "operation": "{topProducts{__typename ...on Book{__typename isbn}...on Furniture{name}}}"
-#               },
-#               {
-#                 "kind": "Flatten",
-#                 "path": ["topProducts", "@"],
-#                 "node": {
-#                   "kind": "Fetch",
-#                   "serviceName": "books",
-#                   "requires": [
-#                     {
-#                       "kind": "InlineFragment",
-#                       "typeCondition": "Book",
-#                       "selections": [
-#                         { "kind": "Field", "name": "__typename" },
-#                         { "kind": "Field", "name": "isbn" }
-#                       ]
-#                     }
-#                   ],
-#                   "variableUsages": [],
-#                   "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
-#                 }
-#               },
-#               {
-#                 "kind": "Flatten",
-#                 "path": ["topProducts", "@"],
-#                 "node": {
-#                   "kind": "Fetch",
-#                   "serviceName": "product",
-#                   "requires": [
-#                     {
-#                       "kind": "InlineFragment",
-#                       "typeCondition": "Book",
-#                       "selections": [
-#                         { "kind": "Field", "name": "__typename" },
-#                         { "kind": "Field", "name": "isbn" },
-#                         { "kind": "Field", "name": "title" },
-#                         { "kind": "Field", "name": "year" }
-#                       ]
-#                     }
-#                   ],
-#                   "variableUsages": [],
-#                   "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
-#                 }
-#               }
-#             ]
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: should use two independent fetches when requesting root fields from two services
+  Given query
+    """
+    query {
+      me {
+        name
+      }
+      topProducts {
+        name
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Parallel",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "accounts",
+            "variableUsages": [],
+            "operation": "{me{name}}"
+          },
+          {
+            "kind": "Sequence",
+            "nodes": [
+              {
+                "kind": "Fetch",
+                "serviceName": "product",
+                "variableUsages": [],
+                "operation": "{topProducts{__typename ...on Book{__typename isbn}...on Furniture{name}}}"
+              },
+              {
+                "kind": "Flatten",
+                "path": ["topProducts", "@"],
+                "node": {
+                  "kind": "Fetch",
+                  "serviceName": "books",
+                  "requires": [
+                    {
+                      "kind": "InlineFragment",
+                      "typeCondition": "Book",
+                      "selections": [
+                        { "kind": "Field", "name": "__typename" },
+                        { "kind": "Field", "name": "isbn" }
+                      ]
+                    }
+                  ],
+                  "variableUsages": [],
+                  "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+                }
+              },
+              {
+                "kind": "Flatten",
+                "path": ["topProducts", "@"],
+                "node": {
+                  "kind": "Fetch",
+                  "serviceName": "product",
+                  "requires": [
+                    {
+                      "kind": "InlineFragment",
+                      "typeCondition": "Book",
+                      "selections": [
+                        { "kind": "Field", "name": "__typename" },
+                        { "kind": "Field", "name": "isbn" },
+                        { "kind": "Field", "name": "title" },
+                        { "kind": "Field", "name": "year" }
+                      ]
+                    }
+                  ],
+                  "variableUsages": [],
+                  "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: should use a single fetch when requesting multiple root fields from the same service
-#   Given query
-#     """
-#     query {
-#       topProducts {
-#         name
-#       }
-#       product(upc: "1") {
-#         name
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "product",
-#             "variableUsages": [],
-#             "operation": "{topProducts{__typename ...on Book{__typename isbn}...on Furniture{name}}product(upc:\"1\"){__typename ...on Book{__typename isbn}...on Furniture{name}}}"
-#           },
-#           {
-#             "kind": "Parallel",
-#             "nodes": [
-#               {
-#                 "kind": "Sequence",
-#                 "nodes": [
-#                   {
-#                     "kind": "Flatten",
-#                     "path": ["topProducts", "@"],
-#                     "node": {
-#                       "kind": "Fetch",
-#                       "serviceName": "books",
-#                       "requires": [
-#                         {
-#                           "kind": "InlineFragment",
-#                           "typeCondition": "Book",
-#                           "selections": [
-#                             { "kind": "Field", "name": "__typename" },
-#                             { "kind": "Field", "name": "isbn" }
-#                           ]
-#                         }
-#                       ],
-#                       "variableUsages": [],
-#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
-#                     }
-#                   },
-#                   {
-#                     "kind": "Flatten",
-#                     "path": ["topProducts", "@"],
-#                     "node": {
-#                       "kind": "Fetch",
-#                       "serviceName": "product",
-#                       "requires": [
-#                         {
-#                           "kind": "InlineFragment",
-#                           "typeCondition": "Book",
-#                           "selections": [
-#                             { "kind": "Field", "name": "__typename" },
-#                             { "kind": "Field", "name": "isbn" },
-#                             { "kind": "Field", "name": "title" },
-#                             { "kind": "Field", "name": "year" }
-#                           ]
-#                         }
-#                       ],
-#                       "variableUsages": [],
-#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
-#                     }
-#                   }
-#                 ]
-#               },
-#               {
-#                 "kind": "Sequence",
-#                 "nodes": [
-#                   {
-#                     "kind": "Flatten",
-#                     "path": ["product"],
-#                     "node": {
-#                       "kind": "Fetch",
-#                       "serviceName": "books",
-#                       "requires": [
-#                         {
-#                           "kind": "InlineFragment",
-#                           "typeCondition": "Book",
-#                           "selections": [
-#                             { "kind": "Field", "name": "__typename" },
-#                             { "kind": "Field", "name": "isbn" }
-#                           ]
-#                         }
-#                       ],
-#                       "variableUsages": [],
-#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
-#                     }
-#                   },
-#                   {
-#                     "kind": "Flatten",
-#                     "path": ["product"],
-#                     "node": {
-#                       "kind": "Fetch",
-#                       "serviceName": "product",
-#                       "requires": [
-#                         {
-#                           "kind": "InlineFragment",
-#                           "typeCondition": "Book",
-#                           "selections": [
-#                             { "kind": "Field", "name": "__typename" },
-#                             { "kind": "Field", "name": "isbn" },
-#                             { "kind": "Field", "name": "title" },
-#                             { "kind": "Field", "name": "year" }
-#                           ]
-#                         }
-#                       ],
-#                       "variableUsages": [],
-#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
-#                     }
-#                   }
-#                 ]
-#               }
-#             ]
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: should use a single fetch when requesting multiple root fields from the same service
+  Given query
+    """
+    query {
+      topProducts {
+        name
+      }
+      product(upc: "1") {
+        name
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "variableUsages": [],
+            "operation": "{topProducts{__typename ...on Book{__typename isbn}...on Furniture{name}}product(upc:\"1\"){__typename ...on Book{__typename isbn}...on Furniture{name}}}"
+          },
+          {
+            "kind": "Parallel",
+            "nodes": [
+              {
+                "kind": "Sequence",
+                "nodes": [
+                  {
+                    "kind": "Flatten",
+                    "path": ["topProducts", "@"],
+                    "node": {
+                      "kind": "Fetch",
+                      "serviceName": "books",
+                      "requires": [
+                        {
+                          "kind": "InlineFragment",
+                          "typeCondition": "Book",
+                          "selections": [
+                            { "kind": "Field", "name": "__typename" },
+                            { "kind": "Field", "name": "isbn" }
+                          ]
+                        }
+                      ],
+                      "variableUsages": [],
+                      "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+                    }
+                  },
+                  {
+                    "kind": "Flatten",
+                    "path": ["topProducts", "@"],
+                    "node": {
+                      "kind": "Fetch",
+                      "serviceName": "product",
+                      "requires": [
+                        {
+                          "kind": "InlineFragment",
+                          "typeCondition": "Book",
+                          "selections": [
+                            { "kind": "Field", "name": "__typename" },
+                            { "kind": "Field", "name": "isbn" },
+                            { "kind": "Field", "name": "title" },
+                            { "kind": "Field", "name": "year" }
+                          ]
+                        }
+                      ],
+                      "variableUsages": [],
+                      "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+                    }
+                  }
+                ]
+              },
+              {
+                "kind": "Sequence",
+                "nodes": [
+                  {
+                    "kind": "Flatten",
+                    "path": ["product"],
+                    "node": {
+                      "kind": "Fetch",
+                      "serviceName": "books",
+                      "requires": [
+                        {
+                          "kind": "InlineFragment",
+                          "typeCondition": "Book",
+                          "selections": [
+                            { "kind": "Field", "name": "__typename" },
+                            { "kind": "Field", "name": "isbn" }
+                          ]
+                        }
+                      ],
+                      "variableUsages": [],
+                      "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+                    }
+                  },
+                  {
+                    "kind": "Flatten",
+                    "path": ["product"],
+                    "node": {
+                      "kind": "Fetch",
+                      "serviceName": "product",
+                      "requires": [
+                        {
+                          "kind": "InlineFragment",
+                          "typeCondition": "Book",
+                          "selections": [
+                            { "kind": "Field", "name": "__typename" },
+                            { "kind": "Field", "name": "isbn" },
+                            { "kind": "Field", "name": "title" },
+                            { "kind": "Field", "name": "year" }
+                          ]
+                        }
+                      ],
+                      "variableUsages": [],
+                      "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: should use a single fetch when requesting relationship subfields from the same service
-#   Given query
-#     """
-#     query {
-#       topReviews {
-#         body
-#         author {
-#           reviews {
-#             body
-#           }
-#         }
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Fetch",
-#         "serviceName": "reviews",
-#         "variableUsages": [],
-#         "operation": "{topReviews{body author{reviews{body}}}}"
-#       }
-#     }
-#     """
+Scenario: should use a single fetch when requesting relationship subfields from the same service
+  Given query
+    """
+    query {
+      topReviews {
+        body
+        author {
+          reviews {
+            body
+          }
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "reviews",
+        "variableUsages": [],
+        "operation": "{topReviews{body author{reviews{body}}}}"
+      }
+    }
+    """
 
-# Scenario: should use a single fetch when requesting relationship subfields and provided keys from the same service
-#   Given query
-#     """
-#     query {
-#       topReviews {
-#         body
-#         author {
-#           id
-#           reviews {
-#             body
-#           }
-#         }
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Fetch",
-#         "serviceName": "reviews",
-#         "variableUsages": [],
-#         "operation": "{topReviews{body author{id reviews{body}}}}"
-#       }
-#     }
-#     """
+Scenario: should use a single fetch when requesting relationship subfields and provided keys from the same service
+  Given query
+    """
+    query {
+      topReviews {
+        body
+        author {
+          id
+          reviews {
+            body
+          }
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "reviews",
+        "variableUsages": [],
+        "operation": "{topReviews{body author{id reviews{body}}}}"
+      }
+    }
+    """
 
-# Scenario: when requesting an extension field from another service, it should add the field's representation requirements to the parent selection set and use a dependent fetch
-#   Given query
-#   """
-#   query {
-#     me {
-#       name
-#       reviews {
-#         body
-#       }
-#     }
-#   }
-#   """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "accounts",
-#             "variableUsages": [],
-#             "operation": "{me{name __typename id}}"
-#           },
-#           {
-#             "kind": "Flatten",
-#             "path": ["me"],
-#             "node": {
-#               "kind": "Fetch",
-#               "serviceName": "reviews",
-#               "requires": [
-#                 {
-#                   "kind": "InlineFragment",
-#                   "typeCondition": "User",
-#                   "selections": [
-#                     { "kind": "Field", "name": "__typename" },
-#                     { "kind": "Field", "name": "id" }
-#                   ]
-#                 }
-#               ],
-#               "variableUsages": [],
-#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body}}}}"
-#             }
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: when requesting an extension field from another service, it should add the field's representation requirements to the parent selection set and use a dependent fetch
+  Given query
+  """
+  query {
+    me {
+      name
+      reviews {
+        body
+      }
+    }
+  }
+  """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "accounts",
+            "variableUsages": [],
+            "operation": "{me{name __typename id}}"
+          },
+          {
+            "kind": "Flatten",
+            "path": ["me"],
+            "node": {
+              "kind": "Fetch",
+              "serviceName": "reviews",
+              "requires": [
+                {
+                  "kind": "InlineFragment",
+                  "typeCondition": "User",
+                  "selections": [
+                    { "kind": "Field", "name": "__typename" },
+                    { "kind": "Field", "name": "id" }
+                  ]
+                }
+              ],
+              "variableUsages": [],
+              "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body}}}}"
+            }
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: when requesting an extension field from another service, when the parent selection set is empty, should add the field's requirements to the parent selection set and use a dependent fetch
-#   Given query
-#     """
-#     query {
-#       me {
-#         reviews {
-#           body
-#         }
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "accounts",
-#             "variableUsages": [],
-#             "operation": "{me{__typename id}}"
-#           },
-#           {
-#             "kind": "Flatten",
-#             "path": ["me"],
-#             "node": {
-#               "kind": "Fetch",
-#               "serviceName": "reviews",
-#               "requires": [
-#                 {
-#                   "kind": "InlineFragment",
-#                   "typeCondition": "User",
-#                   "selections": [
-#                     { "kind": "Field", "name": "__typename" },
-#                     { "kind": "Field", "name": "id" }
-#                   ]
-#                 }
-#               ],
-#               "variableUsages": [],
-#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body}}}}"
-#             }
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: when requesting an extension field from another service, when the parent selection set is empty, should add the field's requirements to the parent selection set and use a dependent fetch
+  Given query
+    """
+    query {
+      me {
+        reviews {
+          body
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "accounts",
+            "variableUsages": [],
+            "operation": "{me{__typename id}}"
+          },
+          {
+            "kind": "Flatten",
+            "path": ["me"],
+            "node": {
+              "kind": "Fetch",
+              "serviceName": "reviews",
+              "requires": [
+                {
+                  "kind": "InlineFragment",
+                  "typeCondition": "User",
+                  "selections": [
+                    { "kind": "Field", "name": "__typename" },
+                    { "kind": "Field", "name": "id" }
+                  ]
+                }
+              ],
+              "variableUsages": [],
+              "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body}}}}"
+            }
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: when requesting an extension field from another service, should only add requirements once
-#   Given query
-#     """
-#     query {
-#       me {
-#         reviews {
-#           body
-#         }
-#         numberOfReviews
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "accounts",
-#             "variableUsages": [],
-#             "operation": "{me{__typename id}}"
-#           },
-#           {
-#             "kind": "Flatten",
-#             "path": ["me"],
-#             "node": {
-#               "kind": "Fetch",
-#               "serviceName": "reviews",
-#               "requires": [
-#                 {
-#                   "kind": "InlineFragment",
-#                   "typeCondition": "User",
-#                   "selections": [
-#                     { "kind": "Field", "name": "__typename" },
-#                     { "kind": "Field", "name": "id" }
-#                   ]
-#                 }
-#               ],
-#               "variableUsages": [],
-#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body}numberOfReviews}}}"
-#             }
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: when requesting an extension field from another service, should only add requirements once
+  Given query
+    """
+    query {
+      me {
+        reviews {
+          body
+        }
+        numberOfReviews
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "accounts",
+            "variableUsages": [],
+            "operation": "{me{__typename id}}"
+          },
+          {
+            "kind": "Flatten",
+            "path": ["me"],
+            "node": {
+              "kind": "Fetch",
+              "serviceName": "reviews",
+              "requires": [
+                {
+                  "kind": "InlineFragment",
+                  "typeCondition": "User",
+                  "selections": [
+                    { "kind": "Field", "name": "__typename" },
+                    { "kind": "Field", "name": "id" }
+                  ]
+                }
+              ],
+              "variableUsages": [],
+              "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{body}numberOfReviews}}}"
+            }
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: when requesting a composite field with subfields from another service, it should add key fields to the parent selection set and use a dependent fetch
-#   Given query
-#     """
-#     query {
-#       topReviews {
-#         body
-#         author {
-#           name
-#         }
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "reviews",
-#             "variableUsages": [],
-#             "operation": "{topReviews{body author{__typename id}}}"
-#           },
-#           {
-#             "kind": "Flatten",
-#             "path": ["topReviews", "@", "author"],
-#             "node": {
-#               "kind": "Fetch",
-#               "serviceName": "accounts",
-#               "requires": [
-#                 {
-#                   "kind": "InlineFragment",
-#                   "typeCondition": "User",
-#                   "selections": [
-#                     { "kind": "Field", "name": "__typename" },
-#                     { "kind": "Field", "name": "id" }
-#                   ]
-#                 }
-#               ],
-#               "variableUsages": [],
-#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}"
-#             }
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: when requesting a composite field with subfields from another service, it should add key fields to the parent selection set and use a dependent fetch
+  Given query
+    """
+    query {
+      topReviews {
+        body
+        author {
+          name
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "variableUsages": [],
+            "operation": "{topReviews{body author{__typename id}}}"
+          },
+          {
+            "kind": "Flatten",
+            "path": ["topReviews", "@", "author"],
+            "node": {
+              "kind": "Fetch",
+              "serviceName": "accounts",
+              "requires": [
+                {
+                  "kind": "InlineFragment",
+                  "typeCondition": "User",
+                  "selections": [
+                    { "kind": "Field", "name": "__typename" },
+                    { "kind": "Field", "name": "id" }
+                  ]
+                }
+              ],
+              "variableUsages": [],
+              "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}"
+            }
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: when requesting a composite field with subfields from another service, when requesting a field defined in another service which requires a field in the base service, it should add the field provided by base service in first Fetch
-#   Given query
-#     """
-#     query {
-#       topCars {
-#         retailPrice
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "product",
-#             "variableUsages": [],
-#             "operation": "{topCars{__typename id price}}"
-#           },
-#           {
-#             "kind": "Flatten",
-#             "path": ["topCars", "@"],
-#             "node": {
-#               "kind": "Fetch",
-#               "serviceName": "reviews",
-#               "requires": [
-#                 {
-#                   "kind": "InlineFragment",
-#                   "typeCondition": "Car",
-#                   "selections": [
-#                     { "kind": "Field", "name": "__typename" },
-#                     { "kind": "Field", "name": "id" },
-#                     { "kind": "Field", "name": "price" }
-#                   ]
-#                 }
-#               ],
-#               "variableUsages": [],
-#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Car{retailPrice}}}"
-#             }
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: when requesting a composite field with subfields from another service, when requesting a field defined in another service which requires a field in the base service, it should add the field provided by base service in first Fetch
+  Given query
+    """
+    query {
+      topCars {
+        retailPrice
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "variableUsages": [],
+            "operation": "{topCars{__typename id price}}"
+          },
+          {
+            "kind": "Flatten",
+            "path": ["topCars", "@"],
+            "node": {
+              "kind": "Fetch",
+              "serviceName": "reviews",
+              "requires": [
+                {
+                  "kind": "InlineFragment",
+                  "typeCondition": "Car",
+                  "selections": [
+                    { "kind": "Field", "name": "__typename" },
+                    { "kind": "Field", "name": "id" },
+                    { "kind": "Field", "name": "price" }
+                  ]
+                }
+              ],
+              "variableUsages": [],
+              "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Car{retailPrice}}}"
+            }
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: when requesting a composite field with subfields from another service, when the parent selection set is empty, it should add key fields to the parent selection set and use a dependent fetch
-#   Given query
-#     """
-#     query {
-#       topReviews {
-#         author {
-#           name
-#         }
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "reviews",
-#             "variableUsages": [],
-#             "operation": "{topReviews{author{__typename id}}}"
-#           },
-#           {
-#             "kind": "Flatten",
-#             "path": ["topReviews", "@", "author"],
-#             "node": {
-#               "kind": "Fetch",
-#               "serviceName": "accounts",
-#               "requires": [
-#                 {
-#                   "kind": "InlineFragment",
-#                   "typeCondition": "User",
-#                   "selections": [
-#                     { "kind": "Field", "name": "__typename" },
-#                     { "kind": "Field", "name": "id" }
-#                   ]
-#                 }
-#               ],
-#               "variableUsages": [],
-#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}"
-#             }
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: when requesting a composite field with subfields from another service, when the parent selection set is empty, it should add key fields to the parent selection set and use a dependent fetch
+  Given query
+    """
+    query {
+      topReviews {
+        author {
+          name
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "variableUsages": [],
+            "operation": "{topReviews{author{__typename id}}}"
+          },
+          {
+            "kind": "Flatten",
+            "path": ["topReviews", "@", "author"],
+            "node": {
+              "kind": "Fetch",
+              "serviceName": "accounts",
+              "requires": [
+                {
+                  "kind": "InlineFragment",
+                  "typeCondition": "User",
+                  "selections": [
+                    { "kind": "Field", "name": "__typename" },
+                    { "kind": "Field", "name": "id" }
+                  ]
+                }
+              ],
+              "variableUsages": [],
+              "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}"
+            }
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: when requesting a relationship field with extension subfields from a different service, it should first fetch the object using a key from the base service and then pass through the requirements
-#   Given query
-#     """
-#     query {
-#       topReviews {
-#         author {
-#           birthDate
-#         }
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "reviews",
-#             "variableUsages": [],
-#             "operation": "{topReviews{author{__typename id}}}"
-#           },
-#           {
-#             "kind": "Flatten",
-#             "path": ["topReviews", "@", "author"],
-#             "node": {
-#               "kind": "Fetch",
-#               "serviceName": "accounts",
-#               "requires": [
-#                 {
-#                   "kind": "InlineFragment",
-#                   "typeCondition": "User",
-#                   "selections": [
-#                     { "kind": "Field", "name": "__typename" },
-#                     { "kind": "Field", "name": "id" }
-#                   ]
-#                 }
-#               ],
-#               "variableUsages": [],
-#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{birthDate}}}"
-#             }
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: when requesting a relationship field with extension subfields from a different service, it should first fetch the object using a key from the base service and then pass through the requirements
+  Given query
+    """
+    query {
+      topReviews {
+        author {
+          birthDate
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "variableUsages": [],
+            "operation": "{topReviews{author{__typename id}}}"
+          },
+          {
+            "kind": "Flatten",
+            "path": ["topReviews", "@", "author"],
+            "node": {
+              "kind": "Fetch",
+              "serviceName": "accounts",
+              "requires": [
+                {
+                  "kind": "InlineFragment",
+                  "typeCondition": "User",
+                  "selections": [
+                    { "kind": "Field", "name": "__typename" },
+                    { "kind": "Field", "name": "id" }
+                  ]
+                }
+              ],
+              "variableUsages": [],
+              "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{birthDate}}}"
+            }
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: for abstract types, it should add __typename when fetching objects of an interface type from a service
-#   Given query
-#     """
-#     query {
-#       topProducts {
-#         price
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Fetch",
-#         "serviceName": "product",
-#         "variableUsages": [],
-#         "operation": "{topProducts{__typename ...on Book{price}...on Furniture{price}}}"
-#       }
-#     }
-#     """
+Scenario: for abstract types, it should add __typename when fetching objects of an interface type from a service
+  Given query
+    """
+    query {
+      topProducts {
+        price
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "product",
+        "variableUsages": [],
+        "operation": "{topProducts{__typename ...on Book{price}...on Furniture{price}}}"
+      }
+    }
+    """
 
-# Scenario: should break up when traversing an extension field on an interface type from a service
-#   Given query
-#     """
-#     query {
-#       topProducts {
-#         price
-#         reviews {
-#           body
-#         }
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "product",
-#             "variableUsages": [],
-#             "operation": "{topProducts{__typename ...on Book{price __typename isbn}...on Furniture{price __typename upc}}}"
-#           },
-#           {
-#             "kind": "Flatten",
-#             "path": ["topProducts", "@"],
-#             "node": {
-#               "kind": "Fetch",
-#               "serviceName": "reviews",
-#               "requires": [
-#                 {
-#                   "kind": "InlineFragment",
-#                   "typeCondition": "Book",
-#                   "selections": [
-#                     { "kind": "Field", "name": "__typename" },
-#                     { "kind": "Field", "name": "isbn" }
-#                   ]
-#                 },
-#                 {
-#                   "kind": "InlineFragment",
-#                   "typeCondition": "Furniture",
-#                   "selections": [
-#                     { "kind": "Field", "name": "__typename" },
-#                     { "kind": "Field", "name": "upc" }
-#                   ]
-#                 }
-#               ],
-#               "variableUsages": [],
-#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{body}}...on Furniture{reviews{body}}}}"
-#             }
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: should break up when traversing an extension field on an interface type from a service
+  Given query
+    """
+    query {
+      topProducts {
+        price
+        reviews {
+          body
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "variableUsages": [],
+            "operation": "{topProducts{__typename ...on Book{price __typename isbn}...on Furniture{price __typename upc}}}"
+          },
+          {
+            "kind": "Flatten",
+            "path": ["topProducts", "@"],
+            "node": {
+              "kind": "Fetch",
+              "serviceName": "reviews",
+              "requires": [
+                {
+                  "kind": "InlineFragment",
+                  "typeCondition": "Book",
+                  "selections": [
+                    { "kind": "Field", "name": "__typename" },
+                    { "kind": "Field", "name": "isbn" }
+                  ]
+                },
+                {
+                  "kind": "InlineFragment",
+                  "typeCondition": "Furniture",
+                  "selections": [
+                    { "kind": "Field", "name": "__typename" },
+                    { "kind": "Field", "name": "upc" }
+                  ]
+                }
+              ],
+              "variableUsages": [],
+              "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{reviews{body}}...on Furniture{reviews{body}}}}"
+            }
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: interface fragments should expand into possible types only
-#   Given query
-#     """
-#     query {
-#       books {
-#         ... on Product {
-#           name
-#           ... on Furniture {
-#             upc
-#           }
-#         }
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "books",
-#             "variableUsages": [],
-#             "operation": "{books{__typename isbn title year}}"
-#           },
-#           {
-#             "kind": "Flatten",
-#             "path": ["books", "@"],
-#             "node": {
-#               "kind": "Fetch",
-#               "serviceName": "product",
-#               "requires": [
-#                 {
-#                   "kind": "InlineFragment",
-#                   "typeCondition": "Book",
-#                   "selections": [
-#                     { "kind": "Field", "name": "__typename" },
-#                     { "kind": "Field", "name": "isbn" },
-#                     { "kind": "Field", "name": "title" },
-#                     { "kind": "Field", "name": "year" }
-#                   ]
-#                 }
-#               ],
-#               "variableUsages": [],
-#               "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
-#             }
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: interface fragments should expand into possible types only
+  Given query
+    """
+    query {
+      books {
+        ... on Product {
+          name
+          ... on Furniture {
+            upc
+          }
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "books",
+            "variableUsages": [],
+            "operation": "{books{__typename isbn title year}}"
+          },
+          {
+            "kind": "Flatten",
+            "path": ["books", "@"],
+            "node": {
+              "kind": "Fetch",
+              "serviceName": "product",
+              "requires": [
+                {
+                  "kind": "InlineFragment",
+                  "typeCondition": "Book",
+                  "selections": [
+                    { "kind": "Field", "name": "__typename" },
+                    { "kind": "Field", "name": "isbn" },
+                    { "kind": "Field", "name": "title" },
+                    { "kind": "Field", "name": "year" }
+                  ]
+                }
+              ],
+              "variableUsages": [],
+              "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+            }
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: interface inside interface should expand into possible types only
-#   Given query
-#     """
-#     query {
-#       product(upc: "") {
-#         details {
-#           country
-#         }
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Fetch",
-#         "serviceName": "product",
-#         "variableUsages": [],
-#         "operation": "{product(upc:\"\"){__typename ...on Book{details{country}}...on Furniture{details{country}}}}"
-#       }
-#     }
-#     """
+Scenario: interface inside interface should expand into possible types only
+  Given query
+    """
+    query {
+      product(upc: "") {
+        details {
+          country
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "product",
+        "variableUsages": [],
+        "operation": "{product(upc:\"\"){__typename ...on Book{details{country}}...on Furniture{details{country}}}}"
+      }
+    }
+    """
 
-# Scenario: experimental compression to downstream services should generate fragments internally to downstream requests
-#   Given query
-#     """
-#     query {
-#       topReviews {
-#         body
-#         author
-#         product {
-#           name
-#           price
-#           details {
-#             country
-#           }
-#         }
-#       }
-#     }
-#     """
-#   When using autofragmentization
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "reviews",
-#             "variableUsages": [],
-#             "operation": "{topReviews{...__QueryPlanFragment_1__}}fragment __QueryPlanFragment_1__ on Review{body author product{...__QueryPlanFragment_0__}}fragment __QueryPlanFragment_0__ on Product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}"
-#           },
-#           {
-#             "kind": "Parallel",
-#             "nodes": [
-#               {
-#                 "kind": "Sequence",
-#                 "nodes": [
-#                   {
-#                     "kind": "Flatten",
-#                     "path": ["topReviews", "@", "product"],
-#                     "node": {
-#                       "kind": "Fetch",
-#                       "serviceName": "books",
-#                       "requires": [
-#                         {
-#                           "kind": "InlineFragment",
-#                           "typeCondition": "Book",
-#                           "selections": [
-#                             { "kind": "Field", "name": "__typename" },
-#                             { "kind": "Field", "name": "isbn" }
-#                           ]
-#                         }
-#                       ],
-#                       "variableUsages": [],
-#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
-#                     }
-#                   },
-#                   {
-#                     "kind": "Flatten",
-#                     "path": ["topReviews", "@", "product"],
-#                     "node": {
-#                       "kind": "Fetch",
-#                       "serviceName": "product",
-#                       "requires": [
-#                         {
-#                           "kind": "InlineFragment",
-#                           "typeCondition": "Book",
-#                           "selections": [
-#                             { "kind": "Field", "name": "__typename" },
-#                             { "kind": "Field", "name": "isbn" },
-#                             { "kind": "Field", "name": "title" },
-#                             { "kind": "Field", "name": "year" }
-#                           ]
-#                         }
-#                       ],
-#                       "variableUsages": [],
-#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
-#                     }
-#                   }
-#                 ]
-#               },
-#               {
-#                 "kind": "Flatten",
-#                 "path": ["topReviews", "@", "product"],
-#                 "node": {
-#                   "kind": "Fetch",
-#                   "serviceName": "product",
-#                   "requires": [
-#                     {
-#                       "kind": "InlineFragment",
-#                       "typeCondition": "Furniture",
-#                       "selections": [
-#                         { "kind": "Field", "name": "__typename" },
-#                         { "kind": "Field", "name": "upc" }
-#                       ]
-#                     },
-#                     {
-#                       "kind": "InlineFragment",
-#                       "typeCondition": "Book",
-#                       "selections": [
-#                         { "kind": "Field", "name": "__typename" },
-#                         { "kind": "Field", "name": "isbn" }
-#                       ]
-#                     }
-#                   ],
-#                   "variableUsages": [],
-#                   "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name price details{country}}...on Book{price details{country}}}}"
-#                 }
-#               }
-#             ]
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: experimental compression to downstream services should generate fragments internally to downstream requests
+  Given query
+    """
+    query {
+      topReviews {
+        body
+        author
+        product {
+          name
+          price
+          details {
+            country
+          }
+        }
+      }
+    }
+    """
+  When using autofragmentization
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "variableUsages": [],
+            "operation": "{topReviews{...__QueryPlanFragment_1__}}fragment __QueryPlanFragment_1__ on Review{body author product{...__QueryPlanFragment_0__}}fragment __QueryPlanFragment_0__ on Product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}"
+          },
+          {
+            "kind": "Parallel",
+            "nodes": [
+              {
+                "kind": "Sequence",
+                "nodes": [
+                  {
+                    "kind": "Flatten",
+                    "path": ["topReviews", "@", "product"],
+                    "node": {
+                      "kind": "Fetch",
+                      "serviceName": "books",
+                      "requires": [
+                        {
+                          "kind": "InlineFragment",
+                          "typeCondition": "Book",
+                          "selections": [
+                            { "kind": "Field", "name": "__typename" },
+                            { "kind": "Field", "name": "isbn" }
+                          ]
+                        }
+                      ],
+                      "variableUsages": [],
+                      "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+                    }
+                  },
+                  {
+                    "kind": "Flatten",
+                    "path": ["topReviews", "@", "product"],
+                    "node": {
+                      "kind": "Fetch",
+                      "serviceName": "product",
+                      "requires": [
+                        {
+                          "kind": "InlineFragment",
+                          "typeCondition": "Book",
+                          "selections": [
+                            { "kind": "Field", "name": "__typename" },
+                            { "kind": "Field", "name": "isbn" },
+                            { "kind": "Field", "name": "title" },
+                            { "kind": "Field", "name": "year" }
+                          ]
+                        }
+                      ],
+                      "variableUsages": [],
+                      "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+                    }
+                  }
+                ]
+              },
+              {
+                "kind": "Flatten",
+                "path": ["topReviews", "@", "product"],
+                "node": {
+                  "kind": "Fetch",
+                  "serviceName": "product",
+                  "requires": [
+                    {
+                      "kind": "InlineFragment",
+                      "typeCondition": "Furniture",
+                      "selections": [
+                        { "kind": "Field", "name": "__typename" },
+                        { "kind": "Field", "name": "upc" }
+                      ]
+                    },
+                    {
+                      "kind": "InlineFragment",
+                      "typeCondition": "Book",
+                      "selections": [
+                        { "kind": "Field", "name": "__typename" },
+                        { "kind": "Field", "name": "isbn" }
+                      ]
+                    }
+                  ],
+                  "variableUsages": [],
+                  "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name price details{country}}...on Book{price details{country}}}}"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: experimental compression to downstream services shouldn't generate fragments for selection sets of length 2 or less
-#   Given query
-#     """
-#     query {
-#       topReviews {
-#         body
-#         author
-#       }
-#     }
-#     """
-#   When using autofragmentization
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Fetch",
-#         "serviceName": "reviews",
-#         "variableUsages": [],
-#         "operation": "{topReviews{body author}}"
-#       }
-#     }
-#     """
+Scenario: experimental compression to downstream services shouldn't generate fragments for selection sets of length 2 or less
+  Given query
+    """
+    query {
+      topReviews {
+        body
+        author
+      }
+    }
+    """
+  When using autofragmentization
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "reviews",
+        "variableUsages": [],
+        "operation": "{topReviews{body author}}"
+      }
+    }
+    """
 
-# Scenario: experimental compression to downstream services should generate fragments for selection sets of length 3 or greater
-#   Given query
-#     """
-#     query {
-#       topReviews {
-#         id
-#         body
-#         author
-#       }
-#     }
-#     """
-#   When using autofragmentization
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Fetch",
-#         "serviceName": "reviews",
-#         "variableUsages": [],
-#         "operation": "{topReviews{...__QueryPlanFragment_0__}}fragment __QueryPlanFragment_0__ on Review{id body author}"
-#       }
-#     }
-#     """
+Scenario: experimental compression to downstream services should generate fragments for selection sets of length 3 or greater
+  Given query
+    """
+    query {
+      topReviews {
+        id
+        body
+        author
+      }
+    }
+    """
+  When using autofragmentization
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "reviews",
+        "variableUsages": [],
+        "operation": "{topReviews{...__QueryPlanFragment_0__}}fragment __QueryPlanFragment_0__ on Review{id body author}"
+      }
+    }
+    """
 
-# Scenario: experimental compression to downstream services should generate fragments correctly when aliases are used
-#   Given query
-#     """
-#     query {
-#       reviews: topReviews {
-#         content: body
-#         author
-#         product {
-#           name
-#           cost: price
-#           details {
-#             origin: country
-#           }
-#         }
-#       }
-#     }
-#     """
-#   When using autofragmentization
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Sequence",
-#         "nodes": [
-#           {
-#             "kind": "Fetch",
-#             "serviceName": "reviews",
-#             "variableUsages": [],
-#             "operation": "{reviews:topReviews{...__QueryPlanFragment_1__}}fragment __QueryPlanFragment_1__ on Review{content:body author product{...__QueryPlanFragment_0__}}fragment __QueryPlanFragment_0__ on Product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}"
-#           },
-#           {
-#             "kind": "Parallel",
-#             "nodes": [
-#               {
-#                 "kind": "Sequence",
-#                 "nodes": [
-#                   {
-#                     "kind": "Flatten",
-#                     "path": ["reviews", "@", "product"],
-#                     "node": {
-#                       "kind": "Fetch",
-#                       "serviceName": "books",
-#                       "requires": [
-#                         {
-#                           "kind": "InlineFragment",
-#                           "typeCondition": "Book",
-#                           "selections": [
-#                             { "kind": "Field", "name": "__typename" },
-#                             { "kind": "Field", "name": "isbn" }
-#                           ]
-#                         }
-#                       ],
-#                       "variableUsages": [],
-#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
-#                     }
-#                   },
-#                   {
-#                     "kind": "Flatten",
-#                     "path": ["reviews", "@", "product"],
-#                     "node": {
-#                       "kind": "Fetch",
-#                       "serviceName": "product",
-#                       "requires": [
-#                         {
-#                           "kind": "InlineFragment",
-#                           "typeCondition": "Book",
-#                           "selections": [
-#                             { "kind": "Field", "name": "__typename" },
-#                             { "kind": "Field", "name": "isbn" },
-#                             { "kind": "Field", "name": "title" },
-#                             { "kind": "Field", "name": "year" }
-#                           ]
-#                         }
-#                       ],
-#                       "variableUsages": [],
-#                       "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
-#                     }
-#                   }
-#                 ]
-#               },
-#               {
-#                 "kind": "Flatten",
-#                 "path": ["reviews", "@", "product"],
-#                 "node": {
-#                   "kind": "Fetch",
-#                   "serviceName": "product",
-#                   "requires": [
-#                     {
-#                       "kind": "InlineFragment",
-#                       "typeCondition": "Furniture",
-#                       "selections": [
-#                         { "kind": "Field", "name": "__typename" },
-#                         { "kind": "Field", "name": "upc" }
-#                       ]
-#                     },
-#                     {
-#                       "kind": "InlineFragment",
-#                       "typeCondition": "Book",
-#                       "selections": [
-#                         { "kind": "Field", "name": "__typename" },
-#                         { "kind": "Field", "name": "isbn" }
-#                       ]
-#                     }
-#                   ],
-#                   "variableUsages": [],
-#                   "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name cost:price details{origin:country}}...on Book{cost:price details{origin:country}}}}"
-#                 }
-#               }
-#             ]
-#           }
-#         ]
-#       }
-#     }
-#     """
+Scenario: experimental compression to downstream services should generate fragments correctly when aliases are used
+  Given query
+    """
+    query {
+      reviews: topReviews {
+        content: body
+        author
+        product {
+          name
+          cost: price
+          details {
+            origin: country
+          }
+        }
+      }
+    }
+    """
+  When using autofragmentization
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Sequence",
+        "nodes": [
+          {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "variableUsages": [],
+            "operation": "{reviews:topReviews{...__QueryPlanFragment_1__}}fragment __QueryPlanFragment_1__ on Review{content:body author product{...__QueryPlanFragment_0__}}fragment __QueryPlanFragment_0__ on Product{__typename ...on Book{__typename isbn}...on Furniture{__typename upc}}"
+          },
+          {
+            "kind": "Parallel",
+            "nodes": [
+              {
+                "kind": "Sequence",
+                "nodes": [
+                  {
+                    "kind": "Flatten",
+                    "path": ["reviews", "@", "product"],
+                    "node": {
+                      "kind": "Fetch",
+                      "serviceName": "books",
+                      "requires": [
+                        {
+                          "kind": "InlineFragment",
+                          "typeCondition": "Book",
+                          "selections": [
+                            { "kind": "Field", "name": "__typename" },
+                            { "kind": "Field", "name": "isbn" }
+                          ]
+                        }
+                      ],
+                      "variableUsages": [],
+                      "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}"
+                    }
+                  },
+                  {
+                    "kind": "Flatten",
+                    "path": ["reviews", "@", "product"],
+                    "node": {
+                      "kind": "Fetch",
+                      "serviceName": "product",
+                      "requires": [
+                        {
+                          "kind": "InlineFragment",
+                          "typeCondition": "Book",
+                          "selections": [
+                            { "kind": "Field", "name": "__typename" },
+                            { "kind": "Field", "name": "isbn" },
+                            { "kind": "Field", "name": "title" },
+                            { "kind": "Field", "name": "year" }
+                          ]
+                        }
+                      ],
+                      "variableUsages": [],
+                      "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}"
+                    }
+                  }
+                ]
+              },
+              {
+                "kind": "Flatten",
+                "path": ["reviews", "@", "product"],
+                "node": {
+                  "kind": "Fetch",
+                  "serviceName": "product",
+                  "requires": [
+                    {
+                      "kind": "InlineFragment",
+                      "typeCondition": "Furniture",
+                      "selections": [
+                        { "kind": "Field", "name": "__typename" },
+                        { "kind": "Field", "name": "upc" }
+                      ]
+                    },
+                    {
+                      "kind": "InlineFragment",
+                      "typeCondition": "Book",
+                      "selections": [
+                        { "kind": "Field", "name": "__typename" },
+                        { "kind": "Field", "name": "isbn" }
+                      ]
+                    }
+                  ],
+                  "variableUsages": [],
+                  "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name cost:price details{origin:country}}...on Book{cost:price details{origin:country}}}}"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
 
-# Scenario: should properly expand nested unions with inline fragments
-#   Given query
-#     """
-#     query {
-#       body {
-#         ... on Image {
-#           ... on Body {
-#             ... on Image {
-#               attributes {
-#                 url
-#               }
-#             }
-#             ... on Text {
-#               attributes {
-#                 bold
-#                 text
-#               }
-#             }
-#           }
-#         }
-#         ... on Text {
-#           attributes {
-#             bold
-#           }
-#         }
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Fetch",
-#         "serviceName": "documents",
-#         "variableUsages": [],
-#         "operation": "{body{__typename ...on Image{attributes{url}}...on Text{attributes{bold}}}}"
-#       }
-#     }
-#     """
+Scenario: should properly expand nested unions with inline fragments
+  Given query
+    """
+    query {
+      body {
+        ... on Image {
+          ... on Body {
+            ... on Image {
+              attributes {
+                url
+              }
+            }
+            ... on Text {
+              attributes {
+                bold
+                text
+              }
+            }
+          }
+        }
+        ... on Text {
+          attributes {
+            bold
+          }
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "documents",
+        "variableUsages": [],
+        "operation": "{body{__typename ...on Image{attributes{url}}...on Text{attributes{bold}}}}"
+      }
+    }
+    """
 
-# Scenario: deduplicates fields / selections regardless of adjacency and type condition nesting for inline fragments
-#   Given query
-#     """
-#     query {
-#       body {
-#         ... on Image {
-#           ... on Text {
-#             attributes {
-#               bold
-#             }
-#           }
-#         }
-#         ... on Body {
-#           ... on Text {
-#             attributes {
-#               bold
-#               text
-#             }
-#           }
-#         }
-#         ... on Text {
-#           attributes {
-#             bold
-#             text
-#           }
-#         }
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Fetch",
-#         "serviceName": "documents",
-#         "variableUsages": [],
-#         "operation": "{body{__typename ...on Text{attributes{bold text}}}}"
-#       }
-#     }
-#     """
+Scenario: deduplicates fields / selections regardless of adjacency and type condition nesting for inline fragments
+  Given query
+    """
+    query {
+      body {
+        ... on Image {
+          ... on Text {
+            attributes {
+              bold
+            }
+          }
+        }
+        ... on Body {
+          ... on Text {
+            attributes {
+              bold
+              text
+            }
+          }
+        }
+        ... on Text {
+          attributes {
+            bold
+            text
+          }
+        }
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "documents",
+        "variableUsages": [],
+        "operation": "{body{__typename ...on Text{attributes{bold text}}}}"
+      }
+    }
+    """
 
-# Scenario: deduplicates fields / selections regardless of adjacency and type condition nesting for named fragment spreads
-#   Given query
-#     """
-#     fragment TextFragment on Text {
-#       attributes {
-#         bold
-#         text
-#       }
-#     }
+Scenario: deduplicates fields / selections regardless of adjacency and type condition nesting for named fragment spreads
+  Given query
+    """
+    fragment TextFragment on Text {
+      attributes {
+        bold
+        text
+      }
+    }
 
-#     query {
-#       body {
-#         ... on Image {
-#           ...TextFragment
-#         }
-#         ... on Body {
-#           ...TextFragment
-#         }
-#         ...TextFragment
-#       }
-#     }
-#     """
-#   Then query plan
-#     """
-#     {
-#       "kind": "QueryPlan",
-#       "node": {
-#         "kind": "Fetch",
-#         "serviceName": "documents",
-#         "variableUsages": [],
-#         "operation": "{body{__typename ...on Text{attributes{bold text}}}}"
-#       }
-#     }
-#     """
+    query {
+      body {
+        ... on Image {
+          ...TextFragment
+        }
+        ... on Body {
+          ...TextFragment
+        }
+        ...TextFragment
+      }
+    }
+    """
+  Then query plan
+    """
+    {
+      "kind": "QueryPlan",
+      "node": {
+        "kind": "Fetch",
+        "serviceName": "documents",
+        "variableUsages": [],
+        "operation": "{body{__typename ...on Text{attributes{bold text}}}}"
+      }
+    }
+    """
 
-# Scenario: supports basic, single-service mutation
-#   Given query
-#   """
-#   mutation Login($username: String!, $password: String!) {
-#     login(username: $username, password: $password) {
-#       id
-#     }
-#   }
-#   """
-#   Then query plan
-#   """
-#   {
-#     "kind": "QueryPlan",
-#     "node": {
-#       "kind": "Fetch",
-#       "serviceName": "accounts",
-#       "variableUsages": [
-#         "username",
-#         "password"
-#       ],
-#       "operation": "mutation($username:String!$password:String!){login(username:$username password:$password){id}}"
-#     }
-#   }
-#   """
+Scenario: supports basic, single-service mutation
+  Given query
+  """
+  mutation Login($username: String!, $password: String!) {
+    login(username: $username, password: $password) {
+      id
+    }
+  }
+  """
+  Then query plan
+  """
+  {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Fetch",
+      "serviceName": "accounts",
+      "variableUsages": [
+        "username",
+        "password"
+      ],
+      "operation": "mutation($username:String!$password:String!){login(username:$username password:$password){id}}"
+    }
+  }
+  """
 
 # ported from: https://github.com/apollographql/apollo-server/blob/main/packages/apollo-gateway/src/__tests__/integration/mutations.test.ts#L13
 Scenario: supports mutations with a cross-service request

--- a/query-planner/tests/cucumber.rs
+++ b/query-planner/tests/cucumber.rs
@@ -67,7 +67,7 @@ mod query_planner_tests {
                 Some(query_string) => {
                     // store the query on context so other steps can acces it
                     context.query = Some(query_string.clone());
-                }, 
+                },
                 None => panic!("no argument to query step")
             }
         };
@@ -77,12 +77,12 @@ mod query_planner_tests {
                 Some(query) => {
                     // todo use a schema here rather than this stub
                     let built_plan = build_query_plan_from_str("type Query { hello: String }", query.as_ref());
-                    
+
                     match &step.docstring {
                         // todo: deserialize from string to query plan
                         Some(_expected_plan_string) => {
                             assert_eq!(built_plan, QueryPlan { foo: "okay then".to_string() });
-                        }, 
+                        },
                         None => panic!("no argument to query plan step")
                     }
                 },

--- a/query-planner/tests/cucumber.rs
+++ b/query-planner/tests/cucumber.rs
@@ -92,18 +92,11 @@ mod query_planner_tests {
     });
 }
 
+// TODO: how to ignore
 cucumber! {
-    // path relative to cargo.lock
     features: "./", // Path to our feature files
     world: crate::MyWorld, // The world needs to be the same for steps and the main cucumber call
     steps: &[
         query_planner_tests::steps // the `steps!` macro creates a `steps` function in a module
     ]
-    // setup: setup, // Optional; called once before everything
-    // before: &[
-    //     a_before_fn // Optional; called before each scenario
-    // ],
-    // after: &[
-    //     an_after_fn // Optional; called after each scenario
-    // ]
 }

--- a/query-planner/tests/cucumber.rs
+++ b/query-planner/tests/cucumber.rs
@@ -1,46 +1,93 @@
 use cucumber::cucumber;
+use std::fmt;
+
+type Result<T> = std::result::Result<T, QueryPlanError>;
+
+// stub out a custom QueryPlanError
+#[derive(Debug, Clone)]
+struct QueryPlanError;
+impl fmt::Display for QueryPlanError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "error in building query plan")
+    }
+}
+
+struct Schema {}
+fn parse_schema(_schema: &str) -> Result<Schema> {
+    Ok(Schema {})
+}
+
+struct Query {}
+fn parse_query(_query: &str) -> Result<Query> {
+    Ok(Query {})
+}
+#[derive(Debug)]
+struct QueryPlan {
+    foo: String,
+}
+impl std::cmp::PartialEq for QueryPlan {
+    fn eq(&self, other: &QueryPlan) -> bool {
+        self.foo == other.foo
+    }
+}
+
+fn build_query_plan(_schema: &Schema, _query: &Query) -> Result<QueryPlan> {
+    Ok(QueryPlan {
+        foo: "okay then".to_string(),
+    })
+}
+
+// // only used by tests for now
+fn build_query_plan_from_str(schema: &str, query: &str) -> QueryPlan {
+    let schema = parse_schema(schema).expect("failed parsing schema");
+    let query = parse_query(query).expect("failed parsing query");
+    build_query_plan(&schema, &query).expect("failed building QueryPlan")
+}
 
 pub struct QueryPlannerTestContext {
     // You can use this struct for mutable context in scenarios.
-    schema: Option<String>,
-    expected_plan: Option<String>,
+    query: Option<String>,
 }
-
 impl cucumber::World for QueryPlannerTestContext {}
 impl std::default::Default for QueryPlannerTestContext {
     fn default() -> QueryPlannerTestContext {
         // This function is called every time a new scenario is started
-        QueryPlannerTestContext {
-            schema: None,
-            expected_plan: None,
-        }
+        QueryPlannerTestContext { query: None }
     }
 }
 
 mod query_planner_tests {
+    use crate::{build_query_plan_from_str, QueryPlan};
     use cucumber::steps;
 
     // Any type that implements cucumber::World + Default can be the world
     steps!(crate::QueryPlannerTestContext => {
         given "query" |context, step| {
             match &step.docstring {
-                Some(schema_string) => {
+                Some(query_string) => {
                     // store the query on context so other steps can acces it
-                    context.schema = Some(schema_string.clone());
+                    context.query = Some(query_string.clone());
                 }, 
-                None => panic!("ew no")
+                None => panic!("no argument to query step")
             }
-            assert_eq!("hi", "hi");
         };
 
         then "query plan" |context, step| {
-            match &step.docstring {
-                Some(expected_plan_string) => {
-                    context.expected_plan = Some(expected_plan_string.clone());
-                }, 
-                None => panic!("ew no")
+            match &context.query {
+                Some(query) => {
+                    // todo use a schema here rather than this stub
+                    let built_plan = build_query_plan_from_str("type Query { hello: String }", query.as_ref());
+                    
+                    match &step.docstring {
+                        // todo: deserialize from string to query plan
+                        Some(_expected_plan_string) => {
+                            assert_eq!(built_plan, QueryPlan { foo: "okay then".to_string() });
+                        }, 
+                        None => panic!("no argument to query plan step")
+                    }
+                },
+                None => std::unreachable!()
             }
-            assert_eq!("", "");
         };
     });
 }

--- a/query-planner/tests/cucumber.rs
+++ b/query-planner/tests/cucumber.rs
@@ -1,0 +1,62 @@
+use cucumber::cucumber;
+
+pub struct QueryPlannerTestContext {
+    // You can use this struct for mutable context in scenarios.
+    schema: Option<String>,
+    expected_plan: Option<String>,
+}
+
+impl cucumber::World for QueryPlannerTestContext {}
+impl std::default::Default for QueryPlannerTestContext {
+    fn default() -> QueryPlannerTestContext {
+        // This function is called every time a new scenario is started
+        QueryPlannerTestContext {
+            schema: None,
+            expected_plan: None,
+        }
+    }
+}
+
+mod query_planner_tests {
+    use cucumber::steps;
+
+    // Any type that implements cucumber::World + Default can be the world
+    steps!(crate::QueryPlannerTestContext => {
+        given "query" |context, step| {
+            match &step.docstring {
+                Some(schema_string) => {
+                    // store the query on context so other steps can acces it
+                    context.schema = Some(schema_string.clone());
+                }, 
+                None => panic!("ew no")
+            }
+            assert_eq!("hi", "hi");
+        };
+
+        then "query plan" |context, step| {
+            match &step.docstring {
+                Some(expected_plan_string) => {
+                    context.expected_plan = Some(expected_plan_string.clone());
+                }, 
+                None => panic!("ew no")
+            }
+            assert_eq!("", "");
+        };
+    });
+}
+
+cucumber! {
+    // path relative to cargo.lock
+    features: "./", // Path to our feature files
+    world: crate::MyWorld, // The world needs to be the same for steps and the main cucumber call
+    steps: &[
+        query_planner_tests::steps // the `steps!` macro creates a `steps` function in a module
+    ]
+    // setup: setup, // Optional; called once before everything
+    // before: &[
+    //     a_before_fn // Optional; called before each scenario
+    // ],
+    // after: &[
+    //     an_after_fn // Optional; called after each scenario
+    // ]
+}


### PR DESCRIPTION
Resolves #103 

This PR takes the existing query planner test suite from the apollo-server repo (cradle) and sets up this project to run them whenever there is a runnable query planner. 

The signature of the query planner that I've stubbed out here is from this discussion https://github.com/apollographql/rust/issues/101#issuecomment-656356447

Right now, you can run this suite by running `cargo test` or `cargo test -p apollo-query-planner --test cucumber`.

Deliverables from #103:

- [x] Be able to iteratively develop on implementation of a Rust build_query_plan using the .feature files introduced in apollographql/apollo-server#4297.
- [x] Ensure that the same tests are also executed within CI.
- [x] All tests to be demonstrated as being executed, but failing, as there is no implementation yet! (And the implementation is out of scope for this issue)
- [x] Wholesale disabling of these tests in order to allow them to be incrementally disabled as the implementation grows to support their use-cases. This disabling might just be demonstrated as a separate commit.
  > this is possible by commenting out the scenarios in the `.feature` file, but I haven't found a way to skip integration tests yet like you can with regular unit tests using `#[ignore]`