### PR TITLE
Change `visit::Map`'s `merge` to take ownership of `child`

### DIFF
--- a/graphql-parser/src/lib.rs
+++ b/graphql-parser/src/lib.rs
@@ -20,11 +20,9 @@
 //! -------------------------------
 //!
 //! ```rust
-//! # extern crate graphql_parser;
 //! use graphql_parser::{parse_query, ParseError};
 //!
-//! # fn parse() -> Result<(), ParseError> {
-//! let ast = parse_query("query MyQuery { field1, field2 }")?;
+//! let ast = parse_query("query MyQuery { field1, field2 }").unwrap();
 //! // Format canonical representation
 //! assert_eq!(format!("{}", ast), "\
 //! query MyQuery {
@@ -32,21 +30,14 @@
 //!   field2
 //! }
 //! ");
-//! # Ok(())
-//! # }
-//! # fn main() {
-//! #    parse().unwrap()
-//! # }
 //! ```
 //!
 //! Example: Parse and Format Schema
 //! --------------------------------
 //!
 //! ```rust
-//! # extern crate graphql_parser;
 //! use graphql_parser::{parse_schema, ParseError};
 //!
-//! # fn parse() -> Result<(), ParseError> {
 //! let ast = parse_schema(r#"
 //!     schema {
 //!         query: Query
@@ -62,7 +53,7 @@
 //!     type User {
 //!         name: String!,
 //!     }
-//! "#)?.to_owned();
+//! "#).unwrap().to_owned();
 //! // Format canonical representation
 //! assert_eq!(format!("{}", ast), "\
 //! schema {
@@ -82,11 +73,6 @@
 //!   name: String!
 //! }
 //! ");
-//! # Ok(())
-//! # }
-//! # fn main() {
-//! #    parse().unwrap()
-//! # }
 //! ```
 //!
 //! Visitors
@@ -107,7 +93,7 @@
 //!   fieldB: String
 //!   fieldC: [String]  
 //! }
-//! "###)?;
+//! "###).unwrap();
 //!
 //! struct Fields {
 //!     output: Vec<String>
@@ -127,7 +113,6 @@
 //! let mut fields = Fields { output: vec![] };
 //! ast.accept(&mut fields);
 //! assert_eq!(fields.output, vec!["fieldA", "fieldB", "fieldC"]);
-//!# Ok::<(), graphql_parser::ParseError>(())
 //! ```
 //!
 //! Example: Map a query into a string
@@ -141,18 +126,20 @@
 //!     someField
 //!     another { ...withFragment @directive }
 //! }
-//! "#)?;
+//! "#).unwrap();
 //! struct ToIndentedNodeTypes {}
+//!
 //! impl Map for ToIndentedNodeTypes {
 //!     // We're mapping the query AST into a string
 //!     type Output = String;
 //!     // The *merge* function controls how we merge child output data up the tree
 //!     // when the map of the child is complete. Here we join parent and child
 //!     // with a newline.
-//!     fn merge(&mut self, parent: String, child: &String) -> String {
+//!     fn merge(&mut self, parent: String, child: String) -> String {
 //!         format!("{}\n{}", parent, child)
 //!     }
 //! }
+//!
 //! impl query::Map for ToIndentedNodeTypes {
 //!     fn query<'a>(&mut self, _: &Document<'a>, stack: &[Self::Output]) -> Self::Output {
 //!         format!("{}query", "  ".repeat(stack.len()))
@@ -177,7 +164,6 @@
 //!       sel
 //!         sel_set
 //!           sel")));
-//!# Ok::<(), graphql_parser::ParseError>(())
 //! ```
 #![warn(missing_debug_implementations)]
 

--- a/graphql-parser/src/query/visit.rs
+++ b/graphql-parser/src/query/visit.rs
@@ -206,7 +206,7 @@ mod tests {
         struct TestMap {}
         impl visit::Map for TestMap {
             type Output = String;
-            fn merge(&mut self, parent: String, child: &String) -> String {
+            fn merge(&mut self, parent: String, child: String) -> String {
                 format!("{}\n{}", parent, child)
             }
         }

--- a/graphql-parser/src/visit.rs
+++ b/graphql-parser/src/visit.rs
@@ -6,12 +6,10 @@
 pub trait Map {
     type Output;
 
-    /// Merge a child output node into a parent output node.
-    ///
-    /// Implementing this method lets you update and/or replace parent nodes
-    /// by including data from their children. The default implementation returns
-    /// the parent output node unchanged.
-    fn merge(&mut self, parent: Self::Output, child: &Self::Output) -> Self::Output {
+    /// Merge a child output node and a parent output node.
+    /// The default implementation returns the parent output node unchanged
+    /// and discards the child output node.
+    fn merge(&mut self, parent: Self::Output, child: Self::Output) -> Self::Output {
         parent
     }
 }
@@ -33,11 +31,11 @@ pub struct Fold<M: Map> {
 
 impl<M: Map> Fold<M> {
     pub fn pop(&mut self) {
-        self.output = self.stack.pop();
-        if self.stack.is_empty() {
-            return;
-        }
-        if let Some(ref child) = self.output {
+        let output = self.stack.pop();
+        if self.stack.is_empty() || output.is_none() {
+            self.output = output;
+        } else {
+            let child = output.expect("bug! is_none is checked above.");
             let parent = self.stack.pop().unwrap();
             self.stack.push(self.map.merge(parent, child));
         }


### PR DESCRIPTION
## Why?

If `Output` is a container type (e.g. a `Vec<T>`), then `merge`'s ergonomics becomes almost useless.
The _borrowed_ child means that merge cannot take ownership of the contents of the container, and so any attempt to implement a mapping that returns a container is rendered impossible without copying/cloning the contents of the container.

## Why is this an ok change? Don't we need to maintain ownership?

Turns out, no. :)

The function that calls `merge` is `Fold.pop`; There is an implicit invariant on the `Fold.pop` function, where if we push into the stack, we definitely call `Fold.pop` again, and override the owned value.
Currently, the owner of the value passed as `child` is `self.output`, but the only call to `merge` is used to `push` to the stack, which means `Fold.pop` will be called again, and the first line of `Fold.pop` overrides `self.output`, and so `self.output` currently maintains ownership for a value that is never read.

In the scenario where we don't call `merge` (the `stack` is empty after popping), the invariant is that this is the scenario where we finished walking the tree, and `output` may be read.

This PR makes that clearer: we `pop` into a local `output` variable, and if we're done visiting, we give ownership to `self.output`, and if we're still pushing into the stack, we give ownership to the `merge` function.

Previously, in case the stack was empty when `Fold.pop` was called, `None` was assigned to `self.output`, I'm not sure when that can happen, but that invariant has not been changed in case it was relied upon.

## Unrelated
those "hidden" lines in doctests (prefixed with `#`) are making examples more confusing and are not needed as far as I can tell.
The code contains `?`, but the `Result` type is hidden, so the doc itself will not make it clear that using `?` is ok because of that specific return type. Then also, Doctests run their code in a `main`, so adding an additional `main` only to call `parse().unwrap()` seems more confusing for an example.