### PR TITLE
Update documenation image links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/apollographql/space-kit/master/src/illustrations/svgs/astronaut1.svg" width="100%" height="144">
+<img src="https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/astronaut1.svg" width="100%" height="144">
 
 # Apollo Contributor Guide
 
@@ -257,4 +257,4 @@ Cutting an `alpha` or `beta` follows the exact same step with the only change co
 
 If you have any problems with this release process, please create an issue and tag [@jbaxleyiii](https://github.com/jbaxleyiii)
 
-<img src="https://raw.githubusercontent.com/apollographql/space-kit/master/src/illustrations/svgs/observatory.svg" width="100%" height="144">
+<img src="https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/observatory.svg" width="100%" height="144">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/apollographql/space-kit/master/src/illustrations/svgs/rocket1.svg" width="100%" height="144">
+<img src="https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/rocket1.svg" width="100%" height="144">
 
 # Apollo CLI
 
@@ -83,4 +83,4 @@ If you ever have any problems, questions, or ideas; the maintainers of this proj
 - [@jbaxleyiii](https://github.com/jbaxleyiii)
 - [@jakedawkins](https://github.com/jakedawkins)
 
-<img src="https://raw.githubusercontent.com/apollographql/space-kit/master/src/illustrations/svgs/telescope.svg" width="100%" height="144">
+<img src="https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/telescope.svg" width="100%" height="144">


### PR DESCRIPTION
Root branch was moved from `master` to `main`. This updates those links for both README and CONTRIBUTING

https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/rocket1.svg
https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/telescope.svg
https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/observatory.svg
https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/astronaut1.svg