### PR TITLE
Caching `target` for macos CI build is flaky; Unknown Cargo issue

### DIFF
--- a/.github/workflows/slow-test.yml
+++ b/.github/workflows/slow-test.yml
@@ -1,0 +1,65 @@
+name: Lint and Tests (all platforms)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [linux, macos, windows]
+        include:
+          - build: linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - build: macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+          - build: windows
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@v2
+
+      ### INSTALL RUST ###
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+
+      ### BUILD CACHE ###
+      - name: Cache Cargo registry, target, index
+        # we skip caching on macos because of the flaky `thiserror_impl` problem.
+        # see https://github.com/apollographql/rust/issues/123
+        if: matrix.build != 'macos'
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/bin
+            ~/.cargo/git
+            target
+          key: ${{ matrix.build }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
+
+      ### RUN TESTS ###
+      - name: Test (cargo test)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: "--workspace --locked -- --nocapture"
+        env:
+          RUST_LOG: debug
+          RUST_BACKTRACE: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Lint and Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,22 +48,7 @@ jobs:
 
   test-no-run:
     name: Compile tests
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        build: [linux, macos, windows]
-        include:
-          - build: linux
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-          - build: macos
-            os: macos-latest
-            target: x86_64-apple-darwin
-          - build: windows
-            os: windows-latest
-            target: x86_64-pc-windows-msvc
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -73,20 +58,21 @@ jobs:
         id: toolchain
         with:
           toolchain: stable
-          target: ${{ matrix.target }}
           profile: minimal
           override: true
 
       ### BUILD CACHE ###
       - name: Cache Cargo registry, target, index
+        if: matrix.build != 'macos'
         uses: actions/cache@v2
         id: cache-cargo
         with:
           path: |
             ~/.cargo/registry
+            ~/.cargo/bin
             ~/.cargo/git
             target
-          key: ${{ matrix.build }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
+          key: linux-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
       ### COMPILE INCLUDING TESTS ###
       # Note: we do this so that we'll cache the compile results/registry even if test might fail
@@ -101,22 +87,7 @@ jobs:
   test:
     name: Test
     needs: test-no-run
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        build: [linux, macos, windows]
-        include:
-          - build: linux
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-          - build: macos
-            os: macos-latest
-            target: x86_64-apple-darwin
-          - build: windows
-            os: windows-latest
-            target: x86_64-pc-windows-msvc
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -126,7 +97,6 @@ jobs:
         id: toolchain
         with:
           toolchain: stable
-          target: ${{ matrix.target }}
           profile: minimal
           override: true
 
@@ -136,9 +106,10 @@ jobs:
         with:
           path: |
             ~/.cargo/registry
+            ~/.cargo/bin
             ~/.cargo/git
             target
-          key: ${{ matrix.build }}-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
+          key: linux-${{ steps.toolchain.outputs.rustc_hash }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
       ### RUN TESTS ###
       - name: Test (cargo test)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/rocket1.svg" width="100%" height="144">
 
-[![Lint and Tests (all platforms)](https://github.com/apollographql/rust/workflows/Lint%20and%20Tests%20(all%20platforms)/badge.svg)](https://github.com/apollographql/rust/actions?query=workflow%3A%22Lint+and+Tests%22+branch%3Amain)
+[![Lint and Tests (all platforms)](https://github.com/apollographql/rust/workflows/Lint%20and%20Tests%20(all%20platforms)/badge.svg)](https://github.com/apollographql/rust/actions?query=branch%3Amain+workflow%3A%22Lint+and+Tests+%28all+platforms%29%22)
 [![Security audit](https://github.com/apollographql/rust/workflows/Security%20audit/badge.svg)](https://github.com/apollographql/rust/actions?query=workflow%3A%22Security+audit%22)
 [![codecov](https://codecov.io/gh/apollographql/rust/branch/main/graph/badge.svg)](https://codecov.io/gh/apollographql/rust)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/rocket1.svg" width="100%" height="144">
 
-[![Lint and Tests](https://github.com/apollographql/rust/workflows/Lint%20and%20Tests/badge.svg)](https://github.com/apollographql/rust/actions?query=workflow%3A%22Lint+and+Tests%22+branch%3Amain)
+[![Lint and Tests (all platforms)](https://github.com/apollographql/rust/workflows/Lint%20and%20Tests%20(all%20platforms)/badge.svg)](https://github.com/apollographql/rust/actions?query=workflow%3A%22Lint+and+Tests%22+branch%3Amain)
 [![Security audit](https://github.com/apollographql/rust/workflows/Security%20audit/badge.svg)](https://github.com/apollographql/rust/actions?query=workflow%3A%22Security+audit%22)
 [![codecov](https://codecov.io/gh/apollographql/rust/branch/main/graph/badge.svg)](https://codecov.io/gh/apollographql/rust)
 


### PR DESCRIPTION
see https://github.com/apollographql/rust/runs/1038067162?check_suite_focus=true
If we disable caching, everything works.
I opened #123 for this problem. In the interim, the CI actions will be separated to [linux only] and [all] so that we could get quick and reliable feedback on PRs from the linux only action. We disabled caching on `macos` for the slow action.