### PR TITLE
Install GNU tar on macos CI as a workaround

### DIFF
--- a/.github/workflows/slow-test.yml
+++ b/.github/workflows/slow-test.yml
@@ -42,7 +42,7 @@ jobs:
 
       ### BUILD CACHE ###
       # NB: We install gnu-tar because BSD tar is buggy on Github's macos machines. https://github.com/actions/cache/issues/403
-      - name: Install GNU tar
+      - name: Install GNU tar (Macos)
         if: matrix.build == 'macos'
         run: |
           brew install gnu-tar

--- a/.github/workflows/slow-test.yml
+++ b/.github/workflows/slow-test.yml
@@ -41,10 +41,13 @@ jobs:
           override: true
 
       ### BUILD CACHE ###
+      # NB: We install gnu-tar because BSD tar is buggy on Github's macos machines. https://github.com/actions/cache/issues/403
+      - name: Install GNU tar
+        if: matrix.build == 'macos'
+        run: |
+          brew install gnu-tar
+          echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
       - name: Cache Cargo registry, target, index
-        # we skip caching on macos because of the flaky `thiserror_impl` problem.
-        # see https://github.com/apollographql/rust/issues/123
-        if: matrix.build != 'macos'
         uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
closes #123 

Read #123 

@ashleygwilliams found this tweet:
![image](https://user-images.githubusercontent.com/161314/91777556-06891600-eba5-11ea-90f5-945b5249d481.png)

Which led to https://github.com/actions/cache/issues/403 which led to https://github.com/dhadka/shadowsocks-rust/pull/1 as a workaround, which works!