### PR TITLE
Update CSDL, fix bug that the update uncovered.

### DIFF
--- a/query-planner/src/groups.rs
+++ b/query-planner/src/groups.rs
@@ -264,11 +264,9 @@ impl<'q> GroupForField<'q> for GroupForSubField<'q> {
                 }
             } else {
                 // We need to go through the base group first.
-                let key_fields = self.context.get_key_fields(
-                    parent_type,
-                    &self.parent_group.service_name,
-                    false,
-                );
+                let key_fields = self
+                    .context
+                    .get_key_fields(parent_type, &owning_service, false);
 
                 if base_service == self.parent_group.service_name {
                     self.parent_group

--- a/query-planner/tests/features/basic/csdl.graphql
+++ b/query-planner/tests/features/basic/csdl.graphql
@@ -116,6 +116,11 @@ type Mutation {
     deleteReview(id: ID!): Boolean @resolve(graph: "reviews")
 }
 
+type Name {
+    first: String
+    last: String
+}
+
 type PasswordAccount
 @owner(graph: "accounts")
 @key(fields: "{email}", graph: "accounts")
@@ -199,12 +204,13 @@ input UpdateReviewInput {
 type User
 @owner(graph: "accounts")
 @key(fields: "{id}", graph: "accounts")
+@key(fields: "{username name { first last }}", graph: "accounts")
 @key(fields: "{id}", graph: "inventory")
 @key(fields: "{id}", graph: "product")
 @key(fields: "{id}", graph: "reviews")
 {
     id: ID!
-    name: String
+    name: Name
     username: String
     birthDate(locale: String): String
     account: AccountType


### PR DESCRIPTION
After digging at it literally all day, @trevor-scheer and I finally found the root cause of a test breaking only on the wasm side.

1. Turns out JS was using a different CSDL, once that added a @key directive to User
2. Once we updated the CSDL, Rust started failing.
3. Looking into the code and debugging with normal tools (@#!@ wasm debugging), the bug was literally replacing one argument to a function with another, this bug exists in the JS implementation today! Trevor will work on fixing it.

Reviewed during pairing. Merging.